### PR TITLE
[Feat] 모바일 접근 모달 UI 및 로직 구현

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1,4 +1,9 @@
 {
+  "mobileModal": {
+    "closeLabel": "Close modal",
+    "title": "For the best experience,\nplease use a desktop.",
+    "imageAlt": "Desktop usage guide"
+  },
   "signup": {
     "title": "Sign Up",
     "emailPlaceholder": "Enter your email",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -1,4 +1,9 @@
 {
+  "mobileModal": {
+    "closeLabel": "모달 닫기",
+    "title": "원활한 이용을 위해\nPC 환경에서 접속해 주세요.",
+    "imageAlt": "PC 이용 안내"
+  },
   "signup": {
     "title": "회원가입",
     "emailPlaceholder": "이메일을 입력해주세요",

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -6,6 +6,7 @@ import { getMessages, setRequestLocale } from "next-intl/server";
 
 import { routing } from "@/i18n/routing";
 import { LanguageType } from "@/types/mypage/language.type";
+import MobileModal from "@/components/common/MobileModal";
 
 export function generateStaticParams() {
   return routing.locales.map((locale) => ({ locale }));
@@ -29,6 +30,7 @@ export default async function LocaleLayout({
 
   return (
     <NextIntlClientProvider locale={locale} messages={messages}>
+      <MobileModal />
       {children}
     </NextIntlClientProvider>
   );

--- a/src/app/[locale]/signup/page.tsx
+++ b/src/app/[locale]/signup/page.tsx
@@ -31,7 +31,7 @@ const SignUp = () => {
             <source src="/videos/guide-optimized.mp4" type="video/mp4" />
           </video>
           <div className="absolute inset-0 bg-gradient-to-b from-[rgba(8,8,8,0.80)] to-[rgba(8,8,8,0.45)]" />
-          <LogoRed className=" z-50 w-[21rem] h-auto" />
+          <LogoRed className=" z-20 w-[21rem] h-auto" />
         </section>
 
         {/* 우측 로그인 */}

--- a/src/components/common/MobileModal.tsx
+++ b/src/components/common/MobileModal.tsx
@@ -1,16 +1,33 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import Image from "next/image";
 import ModalOverlay from "./ModalOverlay";
 import { Close } from "@/assets/icons";
 import mobilePreview from "@/assets/svg/mobile-preview.svg";
+import { useMediaQuery } from "@/hooks/useMediaQuery";
+
+const DESKTOP_CONTAINER_WIDTH = 1244;
 
 const MobileModal = () => {
+  const [isClosed, setIsClosed] = useState(false);
+  const isSmallScreen = useMediaQuery(DESKTOP_CONTAINER_WIDTH);
+
+  useEffect(() => {
+    if (!isSmallScreen) {
+      setIsClosed(false);
+    }
+  }, [isSmallScreen]);
+
+  const handleClose = () => setIsClosed(true);
+
+  if (!isSmallScreen || isClosed) return null;
+
   return (
-    <ModalOverlay className="bg-Black/70" onClose={() => {}}>
+    <ModalOverlay className="bg-Black/70" onClose={handleClose}>
       <div className="bg-Grey-700/90 w-80 rounded-lg flex flex-col items-center gap-11 shadow-[0_0px_12px_rgba(8,8,8,0.25)] backdrop-blur-[5px]">
         <button
-          onClick={() => {}}
+          onClick={handleClose}
           className="absolute top-4 right-4"
           aria-label={"close modal"}
         >
@@ -30,6 +47,7 @@ const MobileModal = () => {
             width={320}
             height={166}
             className="w-full h-auto"
+            priority
           />
         </div>
       </div>

--- a/src/components/common/MobileModal.tsx
+++ b/src/components/common/MobileModal.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import Image from "next/image";
+import ModalOverlay from "./ModalOverlay";
+import { Close } from "@/assets/icons";
+import mobilePreview from "@/assets/svg/mobile-preview.svg";
+
+const MobileModal = () => {
+  return (
+    <ModalOverlay className="bg-Black/70" onClose={() => {}}>
+      <div className="bg-Grey-700/90 w-80 rounded-lg flex flex-col items-center gap-11 shadow-[0_0px_12px_rgba(8,8,8,0.25)] backdrop-blur-[5px]">
+        <button
+          onClick={() => {}}
+          className="absolute top-4 right-4"
+          aria-label={"close modal"}
+        >
+          <Close className="w-6 h-6" />
+        </button>
+        
+        <h1 className="Subhead_2_semibold text-Grey-100 mt-[3.25rem] text-center">
+          원활한 이용을 위해
+          <br />
+          PC 환경에서 접속해 주세요.
+        </h1>
+
+        <div className="w-full h-[166px] overflow-hidden rounded-b-lg mb-11">
+          <Image
+            src={mobilePreview}
+            alt="mobile only"
+            width={320}
+            height={166}
+            className="w-full h-auto"
+          />
+        </div>
+      </div>
+    </ModalOverlay>
+  );
+};
+export default MobileModal;

--- a/src/components/common/MobileModal.tsx
+++ b/src/components/common/MobileModal.tsx
@@ -6,10 +6,12 @@ import ModalOverlay from "./ModalOverlay";
 import { Close } from "@/assets/icons";
 import mobilePreview from "@/assets/svg/mobile-preview.svg";
 import { useMediaQuery } from "@/hooks/useMediaQuery";
+import { useTranslations } from "next-intl";
 
 const DESKTOP_CONTAINER_WIDTH = 1244;
 
 const MobileModal = () => {
+  const t = useTranslations("mobileModal");
   const [isClosed, setIsClosed] = useState(false);
   const isSmallScreen = useMediaQuery(DESKTOP_CONTAINER_WIDTH);
 
@@ -29,21 +31,19 @@ const MobileModal = () => {
         <button
           onClick={handleClose}
           className="absolute top-4 right-4"
-          aria-label={"close modal"}
+          aria-label={t("closeLabel")}
         >
           <Close className="w-6 h-6" />
         </button>
 
-        <h1 className="Subhead_2_semibold text-Grey-100 mt-[3.25rem] text-center">
-          원활한 이용을 위해
-          <br />
-          PC 환경에서 접속해 주세요.
+        <h1 className="Subhead_2_semibold text-Grey-100 mt-[3.25rem] text-center whitespace-pre-line">
+          {t("title")}
         </h1>
 
         <div className="w-full h-[166px] overflow-hidden rounded-b-lg mb-11">
           <Image
             src={mobilePreview}
-            alt="mobile only"
+            alt={t("imageAlt")}
             width={320}
             height={166}
             className="w-full h-auto"

--- a/src/components/common/MobileModal.tsx
+++ b/src/components/common/MobileModal.tsx
@@ -25,7 +25,7 @@ const MobileModal = () => {
 
   return (
     <ModalOverlay className="bg-Black/70" onClose={handleClose}>
-      <div className="bg-Grey-700/90 w-80 rounded-lg flex flex-col items-center gap-11 shadow-[0_0px_12px_rgba(8,8,8,0.25)] backdrop-blur-[5px]">
+      <div className="bg-Grey-700/90 relative w-80 rounded-lg flex flex-col items-center gap-11 shadow-[0_0px_12px_rgba(8,8,8,0.25)] backdrop-blur-[5px]">
         <button
           onClick={handleClose}
           className="absolute top-4 right-4"
@@ -33,7 +33,7 @@ const MobileModal = () => {
         >
           <Close className="w-6 h-6" />
         </button>
-        
+
         <h1 className="Subhead_2_semibold text-Grey-100 mt-[3.25rem] text-center">
           원활한 이용을 위해
           <br />

--- a/src/components/common/ModalOverlay.tsx
+++ b/src/components/common/ModalOverlay.tsx
@@ -5,9 +5,14 @@ import { useEffect } from "react";
 interface ModalOverlayProps {
   onClose: () => void;
   children: React.ReactNode;
+  className?: string;
 }
 
-const ModalOverlay = ({ onClose, children }: ModalOverlayProps) => {
+const ModalOverlay = ({
+  onClose,
+  children,
+  className = "bg-Black/50",
+}: ModalOverlayProps) => {
   useEffect(() => {
     const prevOverflow = document.body.style.overflow;
     document.body.style.overflow = "hidden";
@@ -27,7 +32,7 @@ const ModalOverlay = ({ onClose, children }: ModalOverlayProps) => {
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center">
       <div
-        className="absolute inset-0 bg-Black/50"
+        className={`absolute inset-0 ${className}`}
         onClick={onClose}
         aria-label="close overlay"
       />

--- a/src/hooks/useMediaQuery.ts
+++ b/src/hooks/useMediaQuery.ts
@@ -1,0 +1,22 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+export const useMediaQuery = (maxWidth: number) => {
+  const [isMatch, setIsMatch] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    const mediaQuery = window.matchMedia(`(max-width: ${maxWidth - 1}px)`);
+    setIsMatch(mediaQuery.matches);
+
+    const handleChange = (e: MediaQueryListEvent) => {
+      setIsMatch(e.matches);
+    };
+
+    mediaQuery.addEventListener("change", handleChange);
+
+    return () => mediaQuery.removeEventListener("change", handleChange);
+  }, [maxWidth]);
+
+  return isMatch;
+};


### PR DESCRIPTION
## 💡 PR 타입

- [x] 기능 추가
- [ ] 버그 수정
- [ ] 코드 개선
- [ ] 문서 수정
- [ ] 기타

## 📝 PR 내용

- [locale] 하위 페이지에서 기기 너비 기준 모바일 접근 모달이 노출되도록 구현했습니다. 이에 따라 app/layout.tsx가 아닌 app/[locale]/layout.tsx에 관련 코드를 추가했습니다.

- 피그마 답변에 따라 1244px 미만에서 모달이 노출되도록 했으며, 기기 종류와 무관하게 데스크탑에서도 화면 크기를 줄이면 동일하게 노출되도록 처리했습니다. 따라서 별도의 기기 감지 라이브러리는 사용하지 않고, 화면 너비를 기준으로 판단하는 방식으로 구현했습니다! 해당 로직은 커스텀 훅으로 분리해두었습니다.

- ModalOverlay를 공통 컴포넌트로 사용하기 위해, 배경 투명도는 props로 제어할 수 있도록 수정했습니다.

## 🔍 관련 이슈

- closes #31 


## 📸 작업 화면

<img width="764" height="725" alt="스크린샷 2026-01-28 오후 3 53 51" src="https://github.com/user-attachments/assets/7db771d5-adb5-475e-99c9-74d45b02a353" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 소형 화면용 모달 오버레이가 추가되어 데스크톱 사용 권장 메시지와 미리보기 이미지를 표시하며 사용자가 닫을 수 있습니다.
  * 뷰포트 기반 반응형 감지 기능이 추가되어 모달 표시 여부를 제어합니다.

* **스타일**
  * 가입 페이지 로고의 시각적 스택 순서(z-index)가 조정되었습니다.

* **수정**
  * 모달 오버레이의 배경 스타일을 외부에서 조정할 수 있도록 유연성이 향상되었으며, 다국어(영/한) 텍스트가 추가되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->