### PR TITLE
[Feat] 404 페이지 퍼블리싱

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1,4 +1,10 @@
 {
+  "notFound": {
+    "badge": "404 error",
+    "title": "Page not found",
+    "description": "The page you’re looking for may have been moved,\ndeleted, or the URL may be incorrect.",
+    "homeButton": "Go Home"
+  },
   "signup": {
     "title": "Sign Up",
     "emailPlaceholder": "Enter your email",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -1,4 +1,10 @@
 {
+  "notFound": {
+    "badge": "404 error",
+    "title": "오류가 발생했어요",
+    "description": "주소가 잘못 입력되거나,\n변경 혹은 삭제되어 페이지를 찾을 수 없어요.",
+    "homeButton": "홈으로"
+  },
   "signup": {
     "title": "회원가입",
     "emailPlaceholder": "이메일을 입력해주세요",

--- a/src/app/[locale]/not-found.tsx
+++ b/src/app/[locale]/not-found.tsx
@@ -1,0 +1,7 @@
+import NotFound from "@/components/common/NotFound";
+
+const NotFoundPage = () => {
+  return <NotFound />;
+};
+
+export default NotFoundPage;

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,12 +1,21 @@
 import { NextIntlClientProvider } from "next-intl";
 import { getMessages } from "next-intl/server";
+import { cookies } from "next/headers";
 import NotFound from "@/components/common/NotFound";
+import { routing } from "@/i18n/routing";
+import { LanguageType } from "@/types/mypage/language.type";
 
 export default async function NotFoundPage() {
-  const messages = await getMessages({ locale: "ko" });
+  const cookieStore = await cookies();
+  const localeCookie = cookieStore.get("NEXT_LOCALE")?.value as LanguageType | undefined;
+  const locale = localeCookie && routing.locales.includes(localeCookie)
+    ? localeCookie
+    : routing.defaultLocale;
+
+  const messages = await getMessages({ locale });
 
   return (
-    <NextIntlClientProvider locale="ko" messages={messages}>
+    <NextIntlClientProvider locale={locale} messages={messages}>
       <NotFound />
     </NextIntlClientProvider>
   );

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,13 @@
+import { NextIntlClientProvider } from "next-intl";
+import { getMessages } from "next-intl/server";
+import NotFound from "@/components/common/NotFound";
+
+export default async function NotFoundPage() {
+  const messages = await getMessages({ locale: "ko" });
+
+  return (
+    <NextIntlClientProvider locale="ko" messages={messages}>
+      <NotFound />
+    </NextIntlClientProvider>
+  );
+}

--- a/src/components/common/NotFound.tsx
+++ b/src/components/common/NotFound.tsx
@@ -14,7 +14,7 @@ const NotFound = () => {
       <div className="fixed inset-0 bg-[url('/images/dashboard/create-background.png')] bg-no-repeat bg-top [background-size:100%_auto] -z-10 pointer-events-none opacity-50" />
 
       <div className="flex flex-col items-center justify-center flex-1 pb-[7.8125rem]">
-        <div className="py-2 px-5 bg-White/3 border border-Grey-700 rounded-[80px] text-Grey-100 mb-7">
+        <div className="py-2 px-5 bg-White/[0.03] border border-Grey-700 rounded-[80px] text-Grey-100 mb-7 Subhead_2_medium">
           404 error
         </div>
 

--- a/src/components/common/NotFound.tsx
+++ b/src/components/common/NotFound.tsx
@@ -4,9 +4,11 @@ import Header from "@/components/dashboard/Header";
 import GlassButton from "./GlassButton";
 import { useRouter } from "next/navigation";
 import { PATHS } from "@/constants/common/paths";
+import { useTranslations } from "next-intl";
 
 const NotFound = () => {
-    const router = useRouter();
+  const router = useRouter();
+  const t = useTranslations("notFound");
 
   return (
     <main className="flex flex-col min-h-dvh">
@@ -15,15 +17,13 @@ const NotFound = () => {
 
       <div className="flex flex-col items-center justify-center flex-1 pb-[7.8125rem]">
         <div className="py-2 px-5 bg-White/[0.03] border border-Grey-700 rounded-[80px] text-Grey-100 mb-7 Subhead_2_medium">
-          404 error
+          {t("badge")}
         </div>
 
         <div className="flex flex-col gap-5 text-center mb-[4.5rem]">
-          <h1 className="Heading_1_bold text-White">오류가 발생했어요</h1>
-          <p className="Subhead_2_medium text-Grey-300">
-            주소가 잘못 입력되거나,
-            <br />
-            변경 혹은 삭제되어 페이지를 찾을 수 없어요.
+          <h1 className="Heading_1_bold text-White">{t("title")}</h1>
+          <p className="Subhead_2_medium text-Grey-300 whitespace-pre-line">
+            {t("description")}
           </p>
         </div>
 
@@ -33,7 +33,7 @@ const NotFound = () => {
           className="Body_2_semibold"
           onClick={() => router.push(PATHS.HOME)}
         >
-          홈으로
+          {t("homeButton")}
         </GlassButton>
       </div>
     </main>

--- a/src/components/common/NotFound.tsx
+++ b/src/components/common/NotFound.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import Header from "@/components/dashboard/Header";
+import GlassButton from "./GlassButton";
+import { useRouter } from "next/navigation";
+import { PATHS } from "@/constants/common/paths";
+
+const NotFound = () => {
+    const router = useRouter();
+
+  return (
+    <main className="flex flex-col min-h-dvh">
+      <Header />
+      <div className="fixed inset-0 bg-[url('/images/dashboard/create-background.png')] bg-no-repeat bg-top [background-size:100%_auto] -z-10 pointer-events-none opacity-50" />
+
+      <div className="flex flex-col items-center justify-center flex-1 pb-[7.8125rem]">
+        <div className="py-2 px-5 bg-White/3 border border-Grey-700 rounded-[80px] text-Grey-100 mb-7">
+          404 error
+        </div>
+
+        <div className="flex flex-col gap-5 text-center mb-[4.5rem]">
+          <h1 className="Heading_1_bold text-White">오류가 발생했어요</h1>
+          <p className="Subhead_2_medium text-Grey-300">
+            주소가 잘못 입력되거나,
+            <br />
+            변경 혹은 삭제되어 페이지를 찾을 수 없어요.
+          </p>
+        </div>
+
+        <GlassButton
+          size="xl"
+          variant="red"
+          className="Body_2_semibold"
+          onClick={() => router.push(PATHS.HOME)}
+        >
+          홈으로
+        </GlassButton>
+      </div>
+    </main>
+  );
+};
+
+export default NotFound;

--- a/src/components/mypage/SettingsContent.tsx
+++ b/src/components/mypage/SettingsContent.tsx
@@ -114,7 +114,10 @@ const SettingsContent = () => {
 
         <LanguageDropdown
           value={locale}
-          onChange={(v) => router.replace(pathname, { locale: v })}
+          onChange={(v) => {
+            document.cookie = `NEXT_LOCALE=${v};path=/;max-age=31536000`;
+            router.replace(pathname, { locale: v });
+          }}
         />
       </div>
 

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -34,8 +34,9 @@ export default function proxy(request: NextRequest) {
     return handleI18nRouting(request);
   }
 
-  // 유효하지 않은 경로 → 404
-  return NextResponse.rewrite(new URL("/not-found", request.url));
+  // 유효하지 않은 경로 → URL 유지하면서 404
+  const locale = request.cookies.get("NEXT_LOCALE")?.value || routing.defaultLocale;
+  return NextResponse.rewrite(new URL(`/${locale}${pathname}`, request.url));
 }
 
 export const config = {

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -12,13 +12,17 @@ export default function proxy(request: NextRequest) {
   const { pathname } = request.nextUrl;
 
   // 다국어 처리가 필요 없는 경로
-  if (pathname.startsWith("/price") || pathname.startsWith("/guide") || pathname === "/") {
+  if (
+    pathname.startsWith("/price") ||
+    pathname.startsWith("/guide") ||
+    pathname === "/"
+  ) {
     return NextResponse.next();
   }
 
   // 유효한 locale로 시작하는 경로 → next-intl 처리
   const pathnameHasLocale = routing.locales.some(
-    (locale) => pathname.startsWith(`/${locale}/`) || pathname === `/${locale}`
+    (locale) => pathname.startsWith(`/${locale}/`) || pathname === `/${locale}`,
   );
 
   if (pathnameHasLocale) {
@@ -27,7 +31,7 @@ export default function proxy(request: NextRequest) {
 
   // locale 없이 실제 존재하는 페이지로 접근 → locale 붙여서 리다이렉트
   const isValidPage = localePages.some(
-    (page) => pathname === `/${page}` || pathname.startsWith(`/${page}/`)
+    (page) => pathname === `/${page}` || pathname.startsWith(`/${page}/`),
   );
 
   if (isValidPage) {
@@ -35,14 +39,19 @@ export default function proxy(request: NextRequest) {
   }
 
   // 유효하지 않은 경로 → URL 유지하면서 404
-  const locale = request.cookies.get("NEXT_LOCALE")?.value || routing.defaultLocale;
+  const localeCookie = request.cookies.get("NEXT_LOCALE")?.value;
+  const locale =
+    localeCookie &&
+    routing.locales.includes(localeCookie as (typeof routing.locales)[number])
+      ? localeCookie
+      : routing.defaultLocale;
   return NextResponse.rewrite(new URL(`/${locale}${pathname}`, request.url));
 }
 
 export const config = {
- // 미들웨어를 실행할 경로를 지정합니다.
- matcher: [
-   "/((?!api|_next/static|_next/image|favicon.ico|public|assets|images|videos).*)",
-   "/guide/:path*, /price/:path*, /",
- ],
+  // 미들웨어를 실행할 경로를 지정합니다.
+  matcher: [
+    "/((?!api|_next/static|_next/image|favicon.ico|public|assets|images|videos).*)",
+    "/guide/:path*, /price/:path*, /",
+  ],
 };


### PR DESCRIPTION
## 💡 PR 타입

- [x] 기능 추가
- [ ] 버그 수정
- [ ] 코드 개선
- [ ] 문서 수정
- [ ] 기타

## 📝 PR 내용

- **404 페이지 퍼블리싱**을 진행했습니다.
  /[locale] 라우트에서 발생하는 404를 처리하기 위해 app/[locale]/not-found.tsx를 추가했습니다.
  [locale]/layout.tsx에서 이미 NextIntlClientProvider를 감싸고 있어 Provider 중첩 없이 공통 404 UI 컴포넌트를 렌더링하도록 구성했고, 중복되는 UI는 공통 컴포넌트로 분리했습니다.
  또한 locale 없는 접근 시(루트 404) 대시보드 헤더 번역 이슈로 인해 app/not-found.tsx에서는 Provider로 한 번 더 감싸도록 처리했습니다.

- 최근 사용 언어가 404에서도 유지되도록 쿠키 기반 locale 처리를 추가했습니다.
  LanguageDropdown에서 선택한 언어를 **NEXT_LOCALE 쿠키**로 저장하고,
  locale prefix가 없는 404 경로에서는 해당 쿠키를 기준으로 locale을 결정해 404 페이지를 렌더링합니다.

- 유효하지 않은 경로가 locale 라우팅으로 처리되던 이슈를 수정했습니다.
  /1과 같은 잘못된 경로가 /ko/1로 리다이렉트되던 문제를 해결하기 위해 **middleware 로직을 분기**하여,
  실제 존재하는 페이지만 **locale 라우팅**을 적용하고 그 외 경로는 정상적으로 404 화면이 노출되도록 수정했습니다.

## 🔍 관련 이슈

- closes #30 

## 📸 작업 화면
<img width="1470" height="878" alt="스크린샷 2026-01-28 오후 4 43 10" src="https://github.com/user-attachments/assets/16ff0727-31ba-4e2c-8e3a-cc507750c4d7" />
<img width="1470" height="878" alt="스크린샷 2026-01-28 오후 4 42 56" src="https://github.com/user-attachments/assets/9d2b89e9-4644-4f6b-870b-11935e00d0c3" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 다국어(영/한) 404 페이지 추가 — 지역화된 배지·제목·설명과 홈으로 이동 버튼 제공
  * 로케일별 맞춤 404 페이지 렌더링 지원

* **개선 사항**
  * 언어 변경 시 선택 로케일을 쿠키에 저장해 설정 유지
  * 서버 측 로케일 기반 경로 처리 개선으로 올바른 지역화 페이지로 안내 강화

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->