### PR TITLE
[Feat] 일반 회원가입 및 이메일 발송 API 연동

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -52,6 +52,7 @@
       "passwordAriaLabel": "Password",
       "confirmPasswordPlaceholder": "Confirm Password",
       "confirmPasswordAriaLabel": "Confirm password",
+      "passwordMismatch": "*Passwords do not match.",
       "submit": "Get Started"
     }
   },

--- a/messages/en.json
+++ b/messages/en.json
@@ -29,7 +29,7 @@
     "emailPlaceholder": "Enter your email",
     "termsAgreement": "I agree to the Terms and Conditions and\nPrivacy Policy",
     "submit": "Register",
-    "submitting": "Sending...",
+    "submitting": "Registering...",
     "emailAriaLabel": "Email",
     "hasAccount": "Already have an account?",
     "login": "Log in",

--- a/messages/en.json
+++ b/messages/en.json
@@ -29,6 +29,7 @@
     "emailPlaceholder": "Enter your email",
     "termsAgreement": "I agree to the Terms and Conditions and\nPrivacy Policy",
     "submit": "Register",
+    "submitting": "Sending...",
     "emailAriaLabel": "Email",
     "hasAccount": "Already have an account?",
     "login": "Log in",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -29,7 +29,7 @@
     "emailPlaceholder": "이메일을 입력해주세요",
     "termsAgreement": "약관 및 개인정보 처리방침에 동의합니다.",
     "submit": "등록하기",
-    "submitting": "전송 중...",
+    "submitting": "등록 중...",
     "emailAriaLabel": "이메일",
     "hasAccount": "이미 계정이 있나요?",
     "login": "로그인하기",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -29,6 +29,7 @@
     "emailPlaceholder": "이메일을 입력해주세요",
     "termsAgreement": "약관 및 개인정보 처리방침에 동의합니다.",
     "submit": "등록하기",
+    "submitting": "전송 중...",
     "emailAriaLabel": "이메일",
     "hasAccount": "이미 계정이 있나요?",
     "login": "로그인하기",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -52,6 +52,7 @@
       "passwordAriaLabel": "비밀번호",
       "confirmPasswordPlaceholder": "비밀번호 확인",
       "confirmPasswordAriaLabel": "비밀번호 확인",
+      "passwordMismatch": "*비밀번호가 일치하지 않습니다.",
       "submit": "시작하기"
     }
   },

--- a/src/apis/authApi.ts
+++ b/src/apis/authApi.ts
@@ -26,7 +26,6 @@ export const signup = async (body: SignupRequest): Promise<SignupResponse> => {
 // 로그인
 export const login = async (body: LoginRequest): Promise<LoginResponse> => {
   const response = await axiosInstance.post<LoginResponse>("/auth/login", body);
-
   return response.data;
 };
 

--- a/src/apis/authApi.ts
+++ b/src/apis/authApi.ts
@@ -14,9 +14,7 @@ export const refreshToken = async (): Promise<void> => {
 };
 
 // 회원가입
-export const signup = async (
-  body: SignupRequest,
-): Promise<SignupResponse> => {
+export const signup = async (body: SignupRequest): Promise<SignupResponse> => {
   const response = await axiosInstance.post<SignupResponse>(
     "/auth/signup",
     body,
@@ -26,24 +24,10 @@ export const signup = async (
 };
 
 // 로그인
-export const login = async (
-  body: LoginRequest,
-): Promise<LoginResponse> => {
-  const response = await axiosInstance.post<LoginResponse>(
-    "/auth/login",
-    body,
-  );
+export const login = async (body: LoginRequest): Promise<LoginResponse> => {
+  const response = await axiosInstance.post<LoginResponse>("/auth/login", body);
 
   return response.data;
-};
-
-// 이메일 인증 확인
-export const verifyEmail = async (
-  params: VerifyEmailParams,
-): Promise<void> => {
-  await axiosInstance.get("/auth/email/verification", {
-    params,
-  });
 };
 
 // 이메일 인증 요청

--- a/src/apis/authApi.ts
+++ b/src/apis/authApi.ts
@@ -1,0 +1,54 @@
+import { axiosInstance } from "@/apis/axios";
+import {
+  SignupRequest,
+  SignupResponse,
+  LoginRequest,
+  LoginResponse,
+  VerifyEmailParams,
+  SendVerificationEmailRequest,
+} from "@/types/api/auth.type";
+
+// 토큰 갱신
+export const refreshToken = async (): Promise<void> => {
+  await axiosInstance.post("/auth/token");
+};
+
+// 회원가입
+export const signup = async (
+  body: SignupRequest,
+): Promise<SignupResponse> => {
+  const response = await axiosInstance.post<SignupResponse>(
+    "/auth/signup",
+    body,
+  );
+
+  return response.data;
+};
+
+// 로그인
+export const login = async (
+  body: LoginRequest,
+): Promise<LoginResponse> => {
+  const response = await axiosInstance.post<LoginResponse>(
+    "/auth/login",
+    body,
+  );
+
+  return response.data;
+};
+
+// 이메일 인증 확인
+export const verifyEmail = async (
+  params: VerifyEmailParams,
+): Promise<void> => {
+  await axiosInstance.get("/auth/email/verification", {
+    params,
+  });
+};
+
+// 이메일 인증 요청
+export const sendVerificationEmail = async (
+  body: SendVerificationEmailRequest,
+): Promise<void> => {
+  await axiosInstance.post("/auth/email/verification", body);
+};

--- a/src/apis/axios.ts
+++ b/src/apis/axios.ts
@@ -1,5 +1,7 @@
 import axios from "axios";
 
+import type { SuccessResponse } from "@/types/api/response.type";
+
 const BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL;
 if (!BASE_URL) {
   throw new Error("API_BASE_URL이 정의되지 않았습니다");
@@ -12,4 +14,10 @@ export const axiosInstance = axios.create({
   },
   withCredentials: true,
   timeout: 20000,
+});
+
+axiosInstance.interceptors.response.use((response) => {
+  const body = response.data as SuccessResponse<unknown>;
+  response.data = body.data;
+  return response;
 });

--- a/src/app/[locale]/login/page.tsx
+++ b/src/app/[locale]/login/page.tsx
@@ -8,6 +8,7 @@ import { PATHS } from "@/constants/common/paths";
 import Header from "@/components/dashboard/Header";
 import GlassButton from "@/components/common/GlassButton";
 import { useTranslations } from "next-intl";
+import { useLogin } from "@/hooks/queries/useAuthApi";
 
 export default function Login() {
   const [email, setEmail] = useState("");
@@ -15,9 +16,24 @@ export default function Login() {
   const [isPasswordOpen, setIsPasswordOpen] = useState(false);
   const router = useRouter();
   const t = useTranslations("login");
+  const { mutate: login, isPending } = useLogin();
 
   const onClick = () => {
     setIsPasswordOpen(!isPasswordOpen);
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!email || !password || isPending) return;
+
+    login(
+      { email, password },
+      {
+        onSuccess: () => {
+          router.push(PATHS.DASHBOARD);
+        },
+      },
+    );
   };
 
   return (
@@ -61,7 +77,7 @@ export default function Login() {
               <div className="flex-1 bg-Grey-600 w-full h-[0.0625rem]"></div>
             </div>
 
-            <form action="">
+            <form onSubmit={handleSubmit}>
               <div className="flex flex-col gap-3 mb-7">
                 <LoginInput
                   placeholder={t("emailPlaceholder")}
@@ -81,10 +97,11 @@ export default function Login() {
               </div>
 
               <GlassButton
+                type="submit"
                 size="xl"
                 variant="red"
                 className="Body_2_semibold"
-                disabled={!email || !password}
+                disabled={!email || !password || isPending}
               >
                 {t("submit")}
               </GlassButton>

--- a/src/app/[locale]/signup/page.tsx
+++ b/src/app/[locale]/signup/page.tsx
@@ -1,10 +1,16 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useMemo } from "react";
 import { useFunnel } from "@use-funnel/browser";
 import { useRouter, useSearchParams } from "next/navigation";
+
 import { PATHS } from "@/constants/common/paths";
-import { SIGNUP_FUNNEL_ID } from "@/constants/signup/funnel";
+import {
+  CHANNEL_NAME,
+  MESSAGE_TYPE,
+  SIGNUP_FUNNEL_ID,
+  SIGNUP_STEPS,
+} from "@/constants/signup/funnel";
 import { useSignup } from "@/hooks/queries/useAuthApi";
 
 import EmailInputStep from "@/components/signup/EmailInputStep";
@@ -19,29 +25,39 @@ const SignUp = () => {
   const searchParams = useSearchParams();
   const { mutate: signup, isPending: isSignupPending } = useSignup();
 
+  const emailFromQuery = searchParams.get("email");
+  const hasEmailQuery = !!emailFromQuery;
+
+  const initial = useMemo(() => {
+    if (!hasEmailQuery) {
+      return {
+        step: SIGNUP_STEPS.EMAIL_INPUT,
+        context: { email: "", agreedToTerms: false },
+      };
+    }
+
+    return {
+      step: SIGNUP_STEPS.VERIFICATION_COMPLETE,
+      context: {
+        email: emailFromQuery ?? "",
+        agreedToTerms: true as const,
+        emailVerified: true as const,
+      },
+    };
+  }, [hasEmailQuery, emailFromQuery]);
+
   const funnel = useFunnel<SignupFunnelSteps>({
     id: SIGNUP_FUNNEL_ID,
-    initial: {
-      step: "EmailInput",
-      context: { email: "", agreedToTerms: false },
-    },
+    initial,
   });
 
   useEffect(() => {
-    const email = searchParams.get("email");
+    if (!emailFromQuery) return;
 
-    if (email) {
-      const channel = new BroadcastChannel("signup-verification");
-      channel.postMessage({ type: "email-verified" });
-      channel.close();
-
-      funnel.history.replace("VerificationComplete", {
-        email,
-        agreedToTerms: true,
-        emailVerified: true,
-      });
-    }
-  }, [searchParams]);
+    const channel = new BroadcastChannel(CHANNEL_NAME);
+    channel.postMessage({ type: MESSAGE_TYPE, email: emailFromQuery });
+    channel.close();
+  }, [emailFromQuery]);
 
   return (
     <funnel.Render
@@ -50,7 +66,7 @@ const SignUp = () => {
           email={context.email ?? ""}
           agreedToTerms={context.agreedToTerms ?? false}
           onNext={({ email, agreedToTerms }) => {
-            history.push("EmailSent", { email, agreedToTerms });
+            history.push(SIGNUP_STEPS.EMAIL_SENT, { email, agreedToTerms });
           }}
         />
       )}
@@ -58,7 +74,7 @@ const SignUp = () => {
         <EmailSentStep
           email={context.email}
           onNext={() => {
-            history.push("VerificationComplete", {
+            history.push(SIGNUP_STEPS.VERIFICATION_COMPLETE, {
               ...context,
               emailVerified: true,
             });
@@ -69,7 +85,7 @@ const SignUp = () => {
         <VerificationCompleteStep
           email={context.email}
           onNext={() => {
-            history.push("PasswordSetup", context);
+            history.push(SIGNUP_STEPS.PASSWORD_SETUP, context);
           }}
         />
       )}

--- a/src/app/[locale]/signup/page.tsx
+++ b/src/app/[locale]/signup/page.tsx
@@ -5,6 +5,7 @@ import { useFunnel } from "@use-funnel/browser";
 import { useRouter, useSearchParams } from "next/navigation";
 import { PATHS } from "@/constants/common/paths";
 import { SIGNUP_FUNNEL_ID } from "@/constants/signup/funnel";
+import { useSignup } from "@/hooks/queries/useAuthApi";
 
 import EmailInputStep from "@/components/signup/EmailInputStep";
 import EmailSentStep from "@/components/signup/EmailSentStep";
@@ -16,6 +17,7 @@ import type { SignupFunnelSteps } from "@/types/signup/funnel.type";
 const SignUp = () => {
   const router = useRouter();
   const searchParams = useSearchParams();
+  const { mutate: signup, isPending: isSignupPending } = useSignup();
 
   const funnel = useFunnel<SignupFunnelSteps>({
     id: SIGNUP_FUNNEL_ID,
@@ -74,10 +76,16 @@ const SignUp = () => {
       PasswordSetup={({ context }) => (
         <PasswordSetupStep
           email={context.email}
-          isLoading={false}
+          isLoading={isSignupPending}
           onSubmit={({ password }) => {
-            // TODO: 회원가입 API 연결
-            router.push(PATHS.LOGIN);
+            signup(
+              { email: context.email, password },
+              {
+                onSuccess: () => {
+                  router.push(PATHS.LOGIN);
+                },
+              },
+            );
           }}
         />
       )}

--- a/src/app/[locale]/signup/page.tsx
+++ b/src/app/[locale]/signup/page.tsx
@@ -29,6 +29,10 @@ const SignUp = () => {
     const email = searchParams.get("email");
 
     if (email) {
+      const channel = new BroadcastChannel("signup-verification");
+      channel.postMessage({ type: "email-verified" });
+      channel.close();
+
       funnel.history.replace("VerificationComplete", {
         email,
         agreedToTerms: true,

--- a/src/app/[locale]/signup/page.tsx
+++ b/src/app/[locale]/signup/page.tsx
@@ -1,7 +1,8 @@
 "use client";
 
+import { useEffect } from "react";
 import { useFunnel } from "@use-funnel/browser";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { PATHS } from "@/constants/common/paths";
 import { SIGNUP_FUNNEL_ID } from "@/constants/signup/funnel";
 
@@ -14,6 +15,7 @@ import type { SignupFunnelSteps } from "@/types/signup/funnel.type";
 
 const SignUp = () => {
   const router = useRouter();
+  const searchParams = useSearchParams();
 
   const funnel = useFunnel<SignupFunnelSteps>({
     id: SIGNUP_FUNNEL_ID,
@@ -22,6 +24,18 @@ const SignUp = () => {
       context: { email: "", agreedToTerms: false },
     },
   });
+
+  useEffect(() => {
+    const email = searchParams.get("email");
+
+    if (email) {
+      funnel.history.replace("VerificationComplete", {
+        email,
+        agreedToTerms: true,
+        emailVerified: true,
+      });
+    }
+  }, [searchParams]);
 
   return (
     <funnel.Render

--- a/src/components/signup/EmailInputStep.tsx
+++ b/src/components/signup/EmailInputStep.tsx
@@ -9,6 +9,7 @@ import type { EmailInputStepProps } from "@/types/signup/funnel.type";
 import LoginInput from "@/components/dashboard/login/LoginInput";
 import { useRouter } from "next/navigation";
 import { PATHS } from "@/constants/common/paths";
+import { useSendVerificationEmail } from "@/hooks/queries/useAuthApi";
 
 const EmailInputStep = ({
   email: initialEmail,
@@ -20,14 +21,27 @@ const EmailInputStep = ({
   const [isCheckboxClicked, setIsCheckboxClicked] = useState(initialAgreed);
   const router = useRouter();
   const [email, setEmail] = useState(initialEmail);
+  const { mutate: sendVerificationEmail, isPending } =
+    useSendVerificationEmail();
 
   const isValidEmail = EMAIL_REGEX.test(email);
-  const isSubmitDisabled = !isCheckboxClicked || !isValidEmail;
+  const isSubmitDisabled = !isCheckboxClicked || !isValidEmail || isPending;
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     if (isSubmitDisabled) return;
-    onNext({ email: email.trim(), agreedToTerms: true });
+
+    const trimmedEmail = email.trim();
+    const callbackUrl = `${window.location.origin}/${locale}/signup?email=${encodeURIComponent(trimmedEmail)}`;
+
+    sendVerificationEmail(
+      { email: trimmedEmail, callbackUrl },
+      {
+        onSuccess: () => {
+          onNext({ email: trimmedEmail, agreedToTerms: true });
+        },
+      },
+    );
   };
 
   return (
@@ -68,7 +82,7 @@ const EmailInputStep = ({
           className="Body_2_semibold mt-10 w-full"
           disabled={isSubmitDisabled}
         >
-          {t("submit")}
+          {isPending ? t("submitting") : t("submit")}
         </GlassButton>
       </form>
 

--- a/src/components/signup/EmailSentStep.tsx
+++ b/src/components/signup/EmailSentStep.tsx
@@ -1,17 +1,19 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useTranslations } from "next-intl";
 import GlassButton from "@/components/common/GlassButton";
 import type { EmailSentStepProps } from "@/types/signup/funnel.type";
 
 const EmailSentStep = ({ email, onNext }: EmailSentStepProps) => {
   const t = useTranslations("signup.emailSent");
+  const [isVerified, setIsVerified] = useState(false);
 
   useEffect(() => {
     const channel = new BroadcastChannel("signup-verification");
     channel.onmessage = (event) => {
       if (event.data.type === "email-verified") {
+        setIsVerified(true);
         onNext();
       }
     };
@@ -29,6 +31,7 @@ const EmailSentStep = ({ email, onNext }: EmailSentStepProps) => {
         variant="red"
         size="xl"
         className="Body_2_semibold w-full"
+        disabled={!isVerified}
         onClick={onNext}
       >
         {t("confirm")}

--- a/src/components/signup/EmailSentStep.tsx
+++ b/src/components/signup/EmailSentStep.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState, useCallback } from "react";
 import { useTranslations } from "next-intl";
 import GlassButton from "@/components/common/GlassButton";
 import type { EmailSentStepProps } from "@/types/signup/funnel.type";
@@ -9,17 +9,26 @@ import { CHANNEL_NAME, MESSAGE_TYPE } from "@/constants/signup/funnel";
 const EmailSentStep = ({ email, onNext }: EmailSentStepProps) => {
   const t = useTranslations("signup.emailSent");
   const [isVerified, setIsVerified] = useState(false);
+  const hasMovedRef = useRef(false);
+
+  const safeNext = useCallback(() => {
+    if (hasMovedRef.current) return;
+    hasMovedRef.current = true;
+    onNext();
+  }, [onNext]);
 
   useEffect(() => {
     const channel = new BroadcastChannel(CHANNEL_NAME);
+
     channel.onmessage = (event) => {
-      if (event.data.type === MESSAGE_TYPE) {
-        setIsVerified(true);
-        onNext();
-      }
+      if (event.data?.type !== MESSAGE_TYPE) return;
+
+      setIsVerified(true);
+      safeNext();
     };
+
     return () => channel.close();
-  }, [onNext]);
+  }, [safeNext]);
 
   return (
     <>
@@ -32,8 +41,8 @@ const EmailSentStep = ({ email, onNext }: EmailSentStepProps) => {
         variant="red"
         size="xl"
         className="Body_2_semibold w-full"
-        disabled={!isVerified}
-        onClick={onNext}
+        disabled={!isVerified || hasMovedRef.current}
+        onClick={safeNext}
       >
         {t("confirm")}
       </GlassButton>

--- a/src/components/signup/EmailSentStep.tsx
+++ b/src/components/signup/EmailSentStep.tsx
@@ -4,15 +4,16 @@ import { useEffect, useState } from "react";
 import { useTranslations } from "next-intl";
 import GlassButton from "@/components/common/GlassButton";
 import type { EmailSentStepProps } from "@/types/signup/funnel.type";
+import { CHANNEL_NAME, MESSAGE_TYPE } from "@/constants/signup/funnel";
 
 const EmailSentStep = ({ email, onNext }: EmailSentStepProps) => {
   const t = useTranslations("signup.emailSent");
   const [isVerified, setIsVerified] = useState(false);
 
   useEffect(() => {
-    const channel = new BroadcastChannel("signup-verification");
+    const channel = new BroadcastChannel(CHANNEL_NAME);
     channel.onmessage = (event) => {
-      if (event.data.type === "email-verified") {
+      if (event.data.type === MESSAGE_TYPE) {
         setIsVerified(true);
         onNext();
       }

--- a/src/components/signup/EmailSentStep.tsx
+++ b/src/components/signup/EmailSentStep.tsx
@@ -1,11 +1,22 @@
 "use client";
 
+import { useEffect } from "react";
 import { useTranslations } from "next-intl";
 import GlassButton from "@/components/common/GlassButton";
 import type { EmailSentStepProps } from "@/types/signup/funnel.type";
 
 const EmailSentStep = ({ email, onNext }: EmailSentStepProps) => {
   const t = useTranslations("signup.emailSent");
+
+  useEffect(() => {
+    const channel = new BroadcastChannel("signup-verification");
+    channel.onmessage = (event) => {
+      if (event.data.type === "email-verified") {
+        onNext();
+      }
+    };
+    return () => channel.close();
+  }, [onNext]);
 
   return (
     <>

--- a/src/components/signup/PasswordSetupStep.tsx
+++ b/src/components/signup/PasswordSetupStep.tsx
@@ -64,6 +64,11 @@ const PasswordSetupStep = ({
             value={confirmPassword}
             onChange={setConfirmPassword}
           />
+          {confirmPassword.length > 0 && !isPasswordMatch && (
+            <span className="Body_3_regular text-Red-350">
+              {t("passwordMismatch")}
+            </span>
+          )}
         </div>
 
         <GlassButton

--- a/src/constants/signup/funnel.ts
+++ b/src/constants/signup/funnel.ts
@@ -1,3 +1,6 @@
+export const CHANNEL_NAME = "signup-verification";
+export const MESSAGE_TYPE = "email-verified";
+
 export const SIGNUP_FUNNEL_ID = "s" as const;
 
 export const SIGNUP_STEPS = {

--- a/src/hooks/queries/useAuthApi.ts
+++ b/src/hooks/queries/useAuthApi.ts
@@ -1,0 +1,28 @@
+import { useMutation } from "@tanstack/react-query";
+
+import {
+  signup,
+  login,
+  verifyEmail,
+  sendVerificationEmail,
+} from "@/apis/authApi";
+
+export const useSignup = () =>
+  useMutation({
+    mutationFn: signup,
+  });
+
+export const useLogin = () =>
+  useMutation({
+    mutationFn: login,
+  });
+
+export const useVerifyEmail = () =>
+  useMutation({
+    mutationFn: verifyEmail,
+  });
+
+export const useSendVerificationEmail = () =>
+  useMutation({
+    mutationFn: sendVerificationEmail,
+  });

--- a/src/hooks/queries/useAuthApi.ts
+++ b/src/hooks/queries/useAuthApi.ts
@@ -1,11 +1,6 @@
 import { useMutation } from "@tanstack/react-query";
 
-import {
-  signup,
-  login,
-  verifyEmail,
-  sendVerificationEmail,
-} from "@/apis/authApi";
+import { signup, login, sendVerificationEmail } from "@/apis/authApi";
 
 export const useSignup = () =>
   useMutation({
@@ -15,11 +10,6 @@ export const useSignup = () =>
 export const useLogin = () =>
   useMutation({
     mutationFn: login,
-  });
-
-export const useVerifyEmail = () =>
-  useMutation({
-    mutationFn: verifyEmail,
   });
 
 export const useSendVerificationEmail = () =>

--- a/src/types/api/auth.type.ts
+++ b/src/types/api/auth.type.ts
@@ -1,0 +1,41 @@
+// 회원가입 요청
+export interface SignupRequest {
+  email: string;
+  password: string;
+}
+
+// 회원가입 응답
+export interface SignupResponse {
+  userId: number;
+  email: string;
+  profileImageUrl: string;
+  accessToken: string;
+  refreshToken: string;
+}
+
+// 로그인 요청
+export interface LoginRequest {
+  email: string;
+  password: string;
+}
+
+// 로그인 응답
+export interface LoginResponse {
+  userId: number;
+  email: string;
+  profileImageUrl: string;
+  accessToken: string;
+  refreshToken: string;
+}
+
+// 이메일 인증 확인 (GET)
+export interface VerifyEmailParams {
+  email: string;
+  token: string;
+}
+
+// 이메일 인증 요청 (POST)
+export interface SendVerificationEmailRequest {
+  email: string;
+  callbackUrl: string;
+}


### PR DESCRIPTION
## 💡 PR 타입

- [x] 기능 추가
- [ ] 버그 수정
- [ ] 코드 개선
- [ ] 문서 수정
- [ ] 기타

## 📝 PR 내용

- 일반 회원가입 및 이메일 인증 플로우를 구현하고 관련 API를 연동했습니다.
- 일반 로그인 API를 연동했습니다.

- **EmailInput 퍼널**
  - 이메일 입력 및 약관 동의 후 버튼 클릭 시 **이메일 인증 메일이 발송**되며 다음 단계로 이동합니다.

- **EmailSent 퍼널**
  - 인증 메일 발송 완료 안내 화면을 제공합니다.
  - 이메일 내 인증 링크 클릭 시 **email 쿼리**가 포함된 회원가입 페이지가 열립니다.
  - 기존에 열려 있던 회원가입 탭이 인증 전 상태로 남아 있지 않도록 **BroadcastChannel**을 활용하여 탭 간 상태를 동기화했습니다.
  - 이에 따라 기존 탭에서도 인증 완료 이벤트를 감지해 비활성화되어 있던 “계속하기” 버튼이 활성화되며 **다음 단계로 자동 전환됩니다.**

- **VerificationComplete 퍼널**
  - 이메일 인증이 완료되었음을 안내하는 화면을 제공합니다.
  - “계속하기” 클릭 시 비밀번호 설정 단계로 이동합니다.

- **PasswordSetup 퍼널**
  - 인증된 이메일과 사용자가 입력한 비밀번호를 기반으로 회원가입 API를 호출합니다.
  - 비밀번호 확인 값이 일치하지 않을 경우, **오류 메시지를 노출합니다.**

## 🔍 관련 이슈

- closes #39 
- closes #41 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신기능**
  * 회원가입 플로우에 이메일 검증 프로세스 및 탭/기기 간 자동 인식 추가
  * 이메일 사전 입력(쿼리파라미터 기반) 지원
  * 로그인 및 회원가입 제출에 서버 연동 기반 처리 및 제출 상태 표시 추가
  * 비밀번호 설정 단계에 실시간 불일치 안내 메시지 추가
* **다국어**
  * 영어·한국어 로컬 문자열 추가(등록 중..., 비밀번호가 일치하지 않습니다.)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->