### PR TITLE
[Feat] 마이페이지 API 연동

### DIFF
--- a/src/apis/mypageApi.ts
+++ b/src/apis/mypageApi.ts
@@ -1,0 +1,35 @@
+import { axiosInstance } from "@/apis/axios";
+import {
+  GetMypageResponse,
+  UpdateUsernameRequest,
+  GetProfileUploadUrlResponse,
+  UpdateProfileImageRequest,
+} from "@/types/api/mypage.type";
+
+// 마이페이지 정보 조회
+export const getMypage = async (): Promise<GetMypageResponse> => {
+  const response = await axiosInstance.get<GetMypageResponse>("/mypage");
+  return response.data;
+};
+
+// username 업데이트
+export const updateUsername = async (
+  body: UpdateUsernameRequest,
+): Promise<void> => {
+  await axiosInstance.put("/mypage/username", body);
+};
+
+// 프로필 업로드 URL 가져오기
+export const getProfileUploadUrl =
+  async (): Promise<GetProfileUploadUrlResponse> => {
+    const response =
+      await axiosInstance.get<GetProfileUploadUrlResponse>("/mypage/profile");
+    return response.data;
+  };
+
+// 프로필 이미지 업데이트
+export const updateProfileImage = async (
+  body: UpdateProfileImageRequest,
+): Promise<void> => {
+  await axiosInstance.put("/mypage/profile", body);
+};

--- a/src/components/dashboard/Header.tsx
+++ b/src/components/dashboard/Header.tsx
@@ -8,6 +8,7 @@ import { WorkbenchMode } from "@/types/dashboard/mode.type";
 import { WORKBENCH_TABS } from "@/constants/dashboard/tab";
 import { PATHS, QUERY_KEYS } from "@/constants/common/paths";
 import { useLocale, useTranslations } from "next-intl";
+import { useMypage } from "@/hooks/queries/useMypageApi";
 
 interface HeaderProps {
   back?: boolean;
@@ -26,6 +27,8 @@ const Header = ({ back = false, tab = false, video = false }: HeaderProps) => {
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const userMenuRef = useRef<HTMLDivElement>(null);
+
+  const { data: mypageData } = useMypage();
 
   const mode =
     (searchParams.get(QUERY_KEYS.WORKBENCH_MODE) as WorkbenchMode | null) ??
@@ -159,7 +162,7 @@ const Header = ({ back = false, tab = false, video = false }: HeaderProps) => {
           {isUserOpen && (
             <div className="absolute top-full right-0 pt-5">
               <div className="px-3 py-4 bg-[rgba(40,44,52,0.90)] backdrop-blur-[5px] rounded-[8px] flex flex-col gap-3 Caption_medium text-Grey-100 min-w-[252px] transition-opacity">
-                <div className="px-5 py-2">cnskdjnksc@gmail.com</div>
+                <div className="px-5 py-2">{mypageData?.email}</div>
                 <div className="Body_2_medium text-Grey-300 flex flex-col gap-14">
                   <div className="border-t-Grey-500 border-t pt-2">
                     <button

--- a/src/components/dashboard/Header.tsx
+++ b/src/components/dashboard/Header.tsx
@@ -28,7 +28,7 @@ const Header = ({ back = false, tab = false, video = false }: HeaderProps) => {
   const searchParams = useSearchParams();
   const userMenuRef = useRef<HTMLDivElement>(null);
 
-  const { data: mypageData } = useMypage();
+  const { data: mypageData, isLoading } = useMypage();
 
   const mode =
     (searchParams.get(QUERY_KEYS.WORKBENCH_MODE) as WorkbenchMode | null) ??
@@ -70,10 +70,12 @@ const Header = ({ back = false, tab = false, video = false }: HeaderProps) => {
   }, [isUserOpen]);
 
   const onUserClick = () => {
-    if (!mypageData) {
+    if (!mypageData && !isLoading) {
       router.push(PATHS.LOGIN);
       return;
     }
+
+    if (isLoading) return;
 
     if (!isUserClicked) {
       setIsUserClicked(true);

--- a/src/components/dashboard/Header.tsx
+++ b/src/components/dashboard/Header.tsx
@@ -56,7 +56,10 @@ const Header = ({ back = false, tab = false, video = false }: HeaderProps) => {
 
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
-      if (userMenuRef.current && !userMenuRef.current.contains(event.target as Node)) {
+      if (
+        userMenuRef.current &&
+        !userMenuRef.current.contains(event.target as Node)
+      ) {
         setIsUserOpen(false);
         setIsUserClicked(false);
       }
@@ -67,6 +70,11 @@ const Header = ({ back = false, tab = false, video = false }: HeaderProps) => {
   }, [isUserOpen]);
 
   const onUserClick = () => {
+    if (!mypageData) {
+      router.push(PATHS.LOGIN);
+      return;
+    }
+
     if (!isUserClicked) {
       setIsUserClicked(true);
       setIsUserOpen(true);
@@ -78,6 +86,7 @@ const Header = ({ back = false, tab = false, video = false }: HeaderProps) => {
   };
 
   const userHover = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (!mypageData) return;
     if (isUserClicked) return;
     if (e.type === "mouseenter") setIsUserOpen(true);
     if (e.type === "mouseleave") setIsUserOpen(false);
@@ -159,10 +168,10 @@ const Header = ({ back = false, tab = false, video = false }: HeaderProps) => {
         >
           <Person className="w-7 h-7 cursor-pointer" onClick={onUserClick} />
 
-          {isUserOpen && (
+          {isUserOpen && mypageData && (
             <div className="absolute top-full right-0 pt-5">
               <div className="px-3 py-4 bg-[rgba(40,44,52,0.90)] backdrop-blur-[5px] rounded-[8px] flex flex-col gap-3 Caption_medium text-Grey-100 min-w-[252px] transition-opacity">
-                <div className="px-5 py-2">{mypageData?.email}</div>
+                <div className="px-5 py-2">{mypageData.email}</div>
                 <div className="Body_2_medium text-Grey-300 flex flex-col gap-14">
                   <div className="border-t-Grey-500 border-t pt-2">
                     <button

--- a/src/components/dashboard/login/LoginInput.tsx
+++ b/src/components/dashboard/login/LoginInput.tsx
@@ -44,6 +44,7 @@ const LoginInput = ({
           }
           placeholder={placeholder}
           value={value}
+          autoComplete="on"
           onChange={onChange ? (e) => onChange(e.target.value) : undefined}
           className="bg-Grey-800 py-3 px-4 placeholder:text-Grey-400 text-Grey-100 Body_2_medium w-full rounded-[4px] relative z-10"
           aria-label={ariaLabel}

--- a/src/components/mypage/SettingsContent.tsx
+++ b/src/components/mypage/SettingsContent.tsx
@@ -5,15 +5,35 @@ import LanguageDropdown from "./LanguageDropdown";
 import { LanguageType } from "@/types/mypage/language.type";
 import { useRouter, usePathname } from "@/i18n/routing";
 import { useLocale } from "next-intl";
+import { useMypage, useUpdateUsername } from "@/hooks/queries/useMypageApi";
+import { useProfileImageUpload } from "@/hooks/useProfileImageUpload";
+import Image from "next/image";
 
 const SettingsContent = () => {
   const locale = useLocale() as LanguageType;
   const router = useRouter();
   const pathname = usePathname();
-  const [nickname, setNickname] = useState("임세민");
+
+  const { data: mypageData } = useMypage();
+  const updateUsernameMutation = useUpdateUsername();
+  const { uploadProfileImage, isUploading } = useProfileImageUpload();
+
+  const [nickname, setNickname] = useState("");
   const [isEditingNickname, setIsEditingNickname] = useState(false);
+  const [imageError, setImageError] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
   const nicknameInputRef = useRef<HTMLInputElement>(null);
   const prevNicknameRef = useRef(nickname);
+
+  useEffect(() => {
+    if (mypageData?.username) {
+      setNickname(mypageData.username);
+      prevNicknameRef.current = mypageData.username;
+    }
+    if (mypageData?.profileImage) {
+      setImageError(false);
+    }
+  }, [mypageData]);
 
   useEffect(() => {
     if (isEditingNickname && nicknameInputRef.current) {
@@ -28,9 +48,19 @@ const SettingsContent = () => {
   };
 
   const handleNicknameSubmit = () => {
-    if (nickname.trim()) {
-      prevNicknameRef.current = nickname;
-    } else {
+    if (nickname.trim() && nickname !== prevNicknameRef.current) {
+      updateUsernameMutation.mutate(
+        { username: nickname },
+        {
+          onSuccess: () => {
+            prevNicknameRef.current = nickname;
+          },
+          onError: () => {
+            setNickname(prevNicknameRef.current);
+          },
+        },
+      );
+    } else if (!nickname.trim()) {
       setNickname(prevNicknameRef.current);
     }
     setIsEditingNickname(false);
@@ -45,6 +75,34 @@ const SettingsContent = () => {
     }
   };
 
+  const isValidImageUrl = (url: string | undefined): boolean => {
+    if (!url) return false;
+    return url.startsWith("http://") || url.startsWith("https://");
+  };
+
+  const handleProfileImageClick = () => {
+    fileInputRef.current?.click();
+  };
+
+  const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    try {
+      await uploadProfileImage(file);
+      alert("프로필 이미지가 업데이트되었습니다.");
+    } catch (error) {
+      if (error instanceof Error) {
+        alert(error.message);
+      } else {
+        alert("프로필 이미지 업데이트에 실패했습니다.");
+      }
+    } finally {
+      // input 초기화
+      e.target.value = "";
+    }
+  };
+
   return (
     <>
       {/* 프로필 */}
@@ -54,10 +112,33 @@ const SettingsContent = () => {
 
           <div className="flex items-center gap-5">
             <div className="relative">
-              <ProfileDefault className="w-[4.5rem] h-[4.5rem]" />
+              {mypageData?.profileImage &&
+              isValidImageUrl(mypageData.profileImage) &&
+              !imageError ? (
+                <Image
+                  src={mypageData.profileImage}
+                  alt="프로필 이미지"
+                  width={72}
+                  height={72}
+                  className="w-[4.5rem] h-[4.5rem] rounded-full object-cover"
+                  onError={() => setImageError(true)}
+                />
+              ) : (
+                <ProfileDefault className="w-[4.5rem] h-[4.5rem]" />
+              )}
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept="image/*"
+                onChange={handleFileChange}
+                className="hidden"
+              />
               <button
+                type="button"
                 aria-label="프로필 사진 변경"
-                className="absolute bottom-0 right-0 w-6 h-6 bg-Grey-500 border-Grey-300 border flex items-center justify-center rounded-full"
+                onClick={handleProfileImageClick}
+                disabled={isUploading}
+                className="absolute bottom-0 right-0 w-6 h-6 bg-Grey-500 border-Grey-300 border flex items-center justify-center rounded-full disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 <Pencil className="w-3 h-3" />
               </button>
@@ -96,7 +177,7 @@ const SettingsContent = () => {
                 </button>
               </div>
               <span className="text-Grey-300 Body_2_medium">
-                이메일sndckscsk@gmail.com
+                {mypageData?.email}
               </span>
             </div>
           </div>

--- a/src/hooks/queries/queryKeys.ts
+++ b/src/hooks/queries/queryKeys.ts
@@ -15,4 +15,11 @@ export const queryKeys = {
     categoryList: (params: GetTemplatesByCategoryParams) =>
       [...queryKeys.templates.category(), params] as const,
   },
+
+  mypage: {
+    all: ["mypage"] as const,
+    detail: () => [...queryKeys.mypage.all, "detail"] as const,
+    profileUploadUrl: () =>
+      [...queryKeys.mypage.all, "profileUploadUrl"] as const,
+  },
 } as const;

--- a/src/hooks/queries/useMypageApi.ts
+++ b/src/hooks/queries/useMypageApi.ts
@@ -20,12 +20,6 @@ export const useUpdateUsername = () =>
     mutationFn: updateUsername,
   });
 
-export const useProfileUploadUrl = () =>
-  useQuery({
-    queryKey: queryKeys.mypage.profileUploadUrl(),
-    queryFn: getProfileUploadUrl,
-  });
-
 export const useUpdateProfileImage = () =>
   useMutation({
     mutationFn: updateProfileImage,

--- a/src/hooks/queries/useMypageApi.ts
+++ b/src/hooks/queries/useMypageApi.ts
@@ -1,0 +1,32 @@
+import { useMutation, useQuery } from "@tanstack/react-query";
+
+import {
+  getMypage,
+  updateUsername,
+  getProfileUploadUrl,
+  updateProfileImage,
+} from "@/apis/mypageApi";
+
+import { queryKeys } from "./queryKeys";
+
+export const useMypage = () =>
+  useQuery({
+    queryKey: queryKeys.mypage.detail(),
+    queryFn: getMypage,
+  });
+
+export const useUpdateUsername = () =>
+  useMutation({
+    mutationFn: updateUsername,
+  });
+
+export const useProfileUploadUrl = () =>
+  useQuery({
+    queryKey: queryKeys.mypage.profileUploadUrl(),
+    queryFn: getProfileUploadUrl,
+  });
+
+export const useUpdateProfileImage = () =>
+  useMutation({
+    mutationFn: updateProfileImage,
+  });

--- a/src/hooks/useProfileImageUpload.ts
+++ b/src/hooks/useProfileImageUpload.ts
@@ -19,6 +19,9 @@ export const useProfileImageUpload = () => {
       const uploadResponse = await fetch(uploadUrl, {
         method: "PUT",
         body: file,
+        headers: {
+          "Content-Type": file.type,
+        },
       });
 
       if (!uploadResponse.ok) {

--- a/src/hooks/useProfileImageUpload.ts
+++ b/src/hooks/useProfileImageUpload.ts
@@ -1,0 +1,46 @@
+import { useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { getProfileUploadUrl, updateProfileImage } from "@/apis/mypageApi";
+import { queryKeys } from "@/hooks/queries/queryKeys";
+
+export const useProfileImageUpload = () => {
+  const queryClient = useQueryClient();
+  const [isUploading, setIsUploading] = useState(false);
+
+  const uploadProfileImage = async (file: File) => {
+    if (!file.type.startsWith("image/")) {
+      throw new Error("이미지 파일만 업로드 가능합니다.");
+    }
+
+    setIsUploading(true);
+
+    try {
+      const { uploadUrl, objectKey } = await getProfileUploadUrl();
+      const uploadResponse = await fetch(uploadUrl, {
+        method: "PUT",
+        body: file,
+      });
+
+      if (!uploadResponse.ok) {
+        throw new Error("파일 업로드 실패");
+      }
+
+      await updateProfileImage({ profileImage: objectKey });
+      await queryClient.invalidateQueries({
+        queryKey: queryKeys.mypage.detail(),
+      });
+
+      return { success: true };
+    } catch (error) {
+      console.error("프로필 이미지 업데이트 실패:", error);
+      throw error;
+    } finally {
+      setIsUploading(false);
+    }
+  };
+
+  return {
+    uploadProfileImage,
+    isUploading,
+  };
+};

--- a/src/types/api/auth.type.ts
+++ b/src/types/api/auth.type.ts
@@ -24,8 +24,6 @@ export interface LoginResponse {
   userId: number;
   email: string;
   profileImageUrl: string;
-  accessToken: string;
-  refreshToken: string;
 }
 
 // 이메일 인증 확인 (GET)

--- a/src/types/api/mypage.type.ts
+++ b/src/types/api/mypage.type.ts
@@ -1,0 +1,23 @@
+// 마이페이지 정보 응답
+export interface GetMypageResponse {
+  userId: number;
+  username: string;
+  email: string;
+  profileImage: string;
+}
+
+// username 업데이트 요청
+export interface UpdateUsernameRequest {
+  username: string;
+}
+
+// 프로필 업로드 URL 응답
+export interface GetProfileUploadUrlResponse {
+  uploadUrl: string;
+  objectKey: string;
+}
+
+// 프로필 이미지 업데이트 요청
+export interface UpdateProfileImageRequest {
+  profileImage: string;
+}


### PR DESCRIPTION
## 💡 PR 타입

- [x] 기능 추가
- [ ] 버그 수정
- [ ] 코드 개선
- [ ] 문서 수정
- [ ] 기타

## 📝 PR 내용

- 마이페이지 관련 API 연동을 완료했습니다.
- 프로필 이미지 수정 기능은 현재 백엔드 오류로 인해 프론트 코드만 임시로 추가한 상태이며, 추후 테스트를 진행할 예정입니다.
- 마이페이지 내 닉네임 조회 및 변경, 프로필 이미지 조회 API 연동을 완료했습니다.
- 대시보드 헤더에서 노출되는 모달에 조회 API를 연동하여 사용자 이메일 정보를 표시하도록 구현했습니다.
- 로그인되지 않은 상태에서는 헤더 모달이 열리지 않도록 처리했으며, 클릭 시 로그인 페이지로 이동하도록 로직을 추가했습니다.

## 🔍 관련 이슈

- closes #43 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 마이페이지에서 사용자명 편집 및 서버 연동으로 즉시 반영
  * 프로필 이미지 업로드 기능 추가(업로드 버튼, 업로드 중 비활성화, 유효성 검사 포함)
  * 헤더 및 마이페이지에 동적 사용자 이메일·프로필 이미지 표시 개선(이미지 로드 실패 시 기본 아바타 대체)

* **UI/UX 개선**
  * 로그인 입력 필드에 자동완성 적용

<!-- end of auto-generated comment: release notes by coderabbit.ai -->