### PR TITLE
[Feat] 프로젝트 이어하기 페이지 폴더 디자인 추가

### DIFF
--- a/src/app/[locale]/dashboard/continue/page.tsx
+++ b/src/app/[locale]/dashboard/continue/page.tsx
@@ -7,6 +7,7 @@ import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { useState } from "react";
 import { mockData } from "@/mocks/dashboard/continue.mock";
+import AlertModal from "@/components/common/AlertModal";
 
 const ContinuePage = () => {
   const router = useRouter();
@@ -50,6 +51,18 @@ const ContinuePage = () => {
           </ul>
         </section>
       </main>
+
+       {/* 제거 모달 */}
+      <AlertModal
+        isOpen={deleteModalOpen}
+        onClose={() => setDeleteModalOpen(false)}
+        title="정말 삭제하시겠습니까?"
+        description="폴더를 삭제하면 하위의 폴더와 프로젝트가 모두 삭제되며, 복구할 수 없습니다."
+        buttons={[
+          { label: "닫기", variant: "default", onClick: () => setDeleteModalOpen(false) },
+          { label: "삭제하기", variant: "red", onClick: () => setDeleteModalOpen(false) },
+        ]}
+      />
     </div>
   );
 };

--- a/src/app/[locale]/dashboard/continue/page.tsx
+++ b/src/app/[locale]/dashboard/continue/page.tsx
@@ -2,16 +2,21 @@
 
 import { Back } from "@/assets/icons";
 import Header from "@/components/dashboard/Header";
+import FolderItem from "@/components/dashboard/project/FolderItem";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
+import { useState } from "react";
+import { mockData } from "@/mocks/dashboard/continue.mock";
 
 const ContinuePage = () => {
   const router = useRouter();
   const t = useTranslations("dashboard");
+  const [deleteModalOpen, setDeleteModalOpen] = useState(false);
 
   return (
-    <div className="flex flex-col h-screen relative">
+    <div className="flex flex-col min-h-dvh relative">
       <div className="fixed inset-0 bg-[url('/images/dashboard/continue-background.png')]  bg-no-repeat bg-top [background-size:100%_auto] -z-10 pointer-events-none" />
+      <div className="fixed inset-0 bg-black/75 -z-10 pointer-events-none" />
       <Header />
 
       <button
@@ -23,19 +28,25 @@ const ContinuePage = () => {
         <Back className="w-11 h-11" />
       </button>
 
-      <main className="w-full flex flex-col items-center gap-[4.5rem] flex-1 justify-center mb-[6.75rem]">
+      <main className="w-full flex flex-col items-center gap-[4.5rem] flex-1 mt-[8.25rem] mb-[6.75rem]">
         <div className="flex flex-col gap-3 items-center">
           <span className="py-2 px-5 border border-Grey-700 bg-[rgba(255,255,255,0.03)] Body_2_medium text-Grey-100 rounded-[5rem]">
             {t("continue.badge")}
           </span>
-          <h1 className="Heading_1_bold text-White">
-            {t("continue.title")}
-          </h1>
+          <h1 className="Heading_1_bold text-White">{t("continue.title")}</h1>
         </div>
 
         <section aria-label={t("continue.badge")}>
-          <ul className="flex items-center gap-9">
-            {/* 폴더 디자인 확정 후 작업 */}
+          <ul className="grid grid-cols-3 gap-x-9 gap-y-11">
+            {mockData.map((item, index) => (
+              <li key={index}>
+                <FolderItem
+                  lists={item}
+                  index={index}
+                  setDeleteModalOpen={setDeleteModalOpen}
+                />
+              </li>
+            ))}
           </ul>
         </section>
       </main>

--- a/src/app/[locale]/dashboard/create/page.tsx
+++ b/src/app/[locale]/dashboard/create/page.tsx
@@ -12,7 +12,7 @@ const CreatePage = () => {
   const t = useTranslations("dashboard");
 
   return (
-    <div className="flex flex-col h-screen relative">
+    <div className="flex flex-col min-h-dvh relative">
       <div className="fixed inset-0 bg-[url('/images/dashboard/create-background.png')]  bg-no-repeat bg-top [background-size:100%_auto] -z-10 pointer-events-none" />
       <Header />
 
@@ -25,7 +25,7 @@ const CreatePage = () => {
         <Back className="w-11 h-11" />
       </button>
 
-      <main className="w-full flex flex-col items-center gap-[4.5rem] flex-1 justify-center mb-[6.75rem]">
+      <main className="w-full flex flex-col items-center gap-[4.5rem] flex-1 mt-[8.25rem] mb-[6.75rem]">
         <div className="flex flex-col gap-3 items-center">
           <span className="py-2 px-5 border border-Grey-700 bg-[rgba(255,255,255,0.03)] Body_2_medium text-Grey-100 rounded-[5rem]">
             {t("create.badge")}

--- a/src/components/dashboard/project/CreatFolderModal.tsx
+++ b/src/components/dashboard/project/CreatFolderModal.tsx
@@ -4,7 +4,7 @@ import GlassButton from "@/components/common/GlassButton";
 import ModalOverlay from "@/components/common/ModalOverlay";
 import clsx from "clsx";
 import InvitedUserItem from "./InvitedUserItem";
-import { MOCK_DATA_USERS } from "@/constants/dashboard/project/user";
+import { MOCK_DATA_USERS } from "@/mocks/dashboard/user.mock";
 
 interface CreatFolderModalProps {
   isOpen: boolean;

--- a/src/components/dashboard/project/InviteModal.tsx
+++ b/src/components/dashboard/project/InviteModal.tsx
@@ -1,6 +1,6 @@
 import { useSearchParams } from "next/navigation";
 import InvitedUserItem from "./InvitedUserItem";
-import { MOCK_DATA_USERS } from "@/constants/dashboard/project/user";
+import { MOCK_DATA_USERS } from "@/mocks/dashboard/user.mock";
 import { useState } from "react";
 import clsx from "clsx";
 import ModalOverlay from "@/components/common/ModalOverlay";

--- a/src/mocks/dashboard/continue.mock.ts
+++ b/src/mocks/dashboard/continue.mock.ts
@@ -1,0 +1,47 @@
+export const mockData = [
+  {
+    name: "Handbag",
+    isFolder: true,
+    imageUrl: [1, 2, 3, 4, 5, 6].map(() => "/images/project/mockData.png"),
+  },
+  {
+    name: "Cosmetics Visuals",
+    isFolder: true,
+    imageUrl: [1, 2, 3, 4, 5, 6].map(() => "/images/project/mockData.png"),
+  },
+  {
+    name: "Cosmetics Visuals",
+    isFolder: true,
+    imageUrl: [1, 2, 3, 4, 5, 6].map(() => "/images/project/mockData.png"),
+  },
+  {
+    name: "제목을 입력해주세요",
+    isFolder: false,
+    imageUrl: "/images/project/mockData.png",
+  },
+  {
+    name: "제목을 입력해주세요",
+    isFolder: false,
+    imageUrl: "/images/project/mockData.png",
+  },
+  {
+    name: "제목을 입력해주세요",
+    isFolder: false,
+    imageUrl: "/images/project/mockData.png",
+  },
+  {
+    name: "제목을 입력해주세요",
+    isFolder: false,
+    imageUrl: "/images/project/mockData.png",
+  },
+  {
+    name: "제목을 입력해주세요",
+    isFolder: false,
+    imageUrl: "/images/project/mockData.png",
+  },
+  {
+    name: "제목을 입력해주세요",
+    isFolder: false,
+    imageUrl: "/images/project/mockData.png",
+  },
+];

--- a/src/mocks/dashboard/user.mock.ts
+++ b/src/mocks/dashboard/user.mock.ts
@@ -1,12 +1,4 @@
-export type Permission = "전체 허용" | "편집 허용" | "읽기 허용";
-
-interface User {
-  id: number;
-  name: string;
-  email: string;
-  avatar: string;
-  permission: Permission;
-}
+import { User } from "@/types/dashboard/user.type";
 
 export const MOCK_DATA_USERS: User[] = [
   {

--- a/src/types/dashboard/user.type.ts
+++ b/src/types/dashboard/user.type.ts
@@ -1,0 +1,9 @@
+export type Permission = "전체 허용" | "편집 허용" | "읽기 허용";
+
+export interface User {
+  id: number;
+  name: string;
+  email: string;
+  avatar: string;
+  permission: Permission;
+}


### PR DESCRIPTION
## 💡 PR 타입

- [x] 기능 추가
- [ ] 버그 수정
- [ ] 코드 개선
- [ ] 문서 수정
- [ ] 기타

## 📝 PR 내용

* 프로젝트 이어하기 페이지에 폴더 디자인을 추가했습니다. 
류원님께서 제작해주신 `FolderItem` 컴포넌트를 활용하여 grid 형태로 배치했습니다.
* 목데이터는 추후 제거 및 교체가 용이하도록 상수 폴더가 아닌 `/mocks` 폴더에 분리하여 정리해두었습니다.


## 🔍 관련 이슈

- closes #48 


## 📸 작업 화면
<img width="1456" height="769" alt="스크린샷 2026-02-14 오후 1 21 22" src="https://github.com/user-attachments/assets/b51aedf3-62bb-4707-b8d6-7375741ea4a1" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * Continue 대시보드에 실제 폴더 항목 그리드 표시 및 삭제 확인 모달 추가

* **UI 개선**
  * 대시보드 상단 여백 및 레이아웃·간격 조정, 배경 어둡기 오버레이 적용, 제목 줄바꿈 방지

* **기타(데이터/타입)**
  * 대시보드용 목업 데이터와 사용자 타입 정의 추가/정리
<!-- end of auto-generated comment: release notes by coderabbit.ai -->