### PR TITLE
[Feat] Template 도메인 API 연동

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -141,7 +141,8 @@
     "template": {
       "sectionTitle": "Start with a sample template",
       "imageAlt": "Template {id}",
-      "hoverText": "Generate image\nwith this background"
+      "hoverText": "Generate image\nwith this background",
+      "empty": "No templates available"
     },
     "create": {
       "badge": "Start New Project",

--- a/messages/en.json
+++ b/messages/en.json
@@ -196,7 +196,8 @@
           "outdoor": "Outdoor"
         },
         "uploadBackground": "Upload Background",
-        "generate": "Generate"
+        "generate": "Generate",
+        "noSearchResults": "No search results found"
       },
       "optionsTab": {
         "selectQuality": "Select video quality",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -196,7 +196,8 @@
           "outdoor": "아웃도어"
         },
         "uploadBackground": "배경 업로드",
-        "generate": "생성하기"
+        "generate": "생성하기",
+        "noSearchResults": "검색 결과가 없습니다"
       },
       "optionsTab": {
         "selectQuality": "비디오 화질을 선택하세요",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -141,7 +141,8 @@
     "template": {
       "sectionTitle": "예시 템플릿으로 시작하기",
       "imageAlt": "템플릿 {id}",
-      "hoverText": "이 배경으로\n이미지 생성하기"
+      "hoverText": "이 배경으로\n이미지 생성하기",
+      "empty": "사용 가능한 템플릿이 없습니다"
     },
     "create": {
       "badge": "새 프로젝트 시작하기",

--- a/src/apis/axios.ts
+++ b/src/apis/axios.ts
@@ -2,6 +2,7 @@ import axios from "axios";
 
 import { BASE_URL } from "./config";
 import type { SuccessResponse } from "@/types/api/response.type";
+import { PATHS } from "@/constants/common/paths";
 
 if (!BASE_URL) {
   throw new Error("API_BASE_URL이 정의되지 않았습니다");
@@ -16,8 +17,16 @@ export const axiosInstance = axios.create({
   timeout: 20000,
 });
 
-axiosInstance.interceptors.response.use((response) => {
-  const body = response.data as SuccessResponse<unknown>;
-  response.data = body.data;
-  return response;
-});
+axiosInstance.interceptors.response.use(
+  (response) => {
+    const body = response.data as SuccessResponse<unknown>;
+    response.data = body.data;
+    return response;
+  },
+  (error) => {
+    if (error.response?.status === 403 && !window.location.pathname.includes(PATHS.LOGIN)) {
+      window.location.href = PATHS.LOGIN;
+    }
+    return Promise.reject(error);
+  },
+);

--- a/src/apis/templateApi.ts
+++ b/src/apis/templateApi.ts
@@ -4,7 +4,30 @@ import {
   GetTemplatesByCategoryResponse,
   GetTemplatesByKeywordParams,
   GetTemplatesByKeywordResponse,
+  GetTemplateKeywordsResponse,
+  SearchTemplatesParams,
+  SearchTemplatesResponse,
 } from "@/types/api/template.type";
+
+export const getTemplateKeywords =
+  async (): Promise<GetTemplateKeywordsResponse> => {
+    const response = await axiosInstance.get<GetTemplateKeywordsResponse>(
+      "/templates/template-keywords",
+    );
+
+    return response.data;
+  };
+
+export const getSearchTemplates = async (
+  params: SearchTemplatesParams,
+): Promise<SearchTemplatesResponse> => {
+  const response = await axiosInstance.get<SearchTemplatesResponse>(
+    "/templates/search",
+    { params },
+  );
+
+  return response.data;
+};
 
 export const getTemplatesByKeyword = async (
   params: GetTemplatesByKeywordParams,

--- a/src/apis/templateApi.ts
+++ b/src/apis/templateApi.ts
@@ -31,8 +31,8 @@ export const getSearchTemplates = async (
 
 export const getTemplatesByKeyword = async (
   params: GetTemplatesByKeywordParams,
-): Promise<GetTemplatesByKeywordResponse> => {
-  const response = await axiosInstance.get<GetTemplatesByKeywordResponse>(
+): Promise<GetTemplatesByKeywordResponse[]> => {
+  const response = await axiosInstance.get<GetTemplatesByKeywordResponse[]>(
     "/templates/keyword",
     {
       params,

--- a/src/app/[locale]/dashboard/page.tsx
+++ b/src/app/[locale]/dashboard/page.tsx
@@ -95,41 +95,46 @@ const DashboardPage = () => {
                         {t("template.empty")}
                       </p>
                     ) : (
-                    <div className="grid grid-cols-5 gap-x-4 gap-y-6">
-                      {showSkeleton
-                        ? Array.from({ length: 15 }, (_, i) => (
-                            <div
-                              key={`skeleton-${i}`}
-                              className="w-[11rem] h-[11rem] rounded overflow-hidden"
-                            >
-                              <div className="w-full h-full bg-Grey-600 animate-pulse" />
-                            </div>
-                          ))
-                        : templates.map((template) => (
-                            <div
-                              key={template.templateId}
-                              tabIndex={0}
-                              role="button"
-                              className="w-[11rem] h-[11rem] relative aspect-square rounded overflow-hidden bg-Grey-200 group box-border border border-transparent hover:border-Red-400"
-                              onClick={() => handleTemplateClick(template.templateId)}
-                              onKeyDown={(e) => e.key === "Enter" && handleTemplateClick(template.templateId)}
-                            >
-                              <Image
-                                src={template.imageUrl}
-                                alt={t("template.imageAlt", {
-                                  id: template.templateId,
-                                })}
-                                fill
-                                className="object-cover"
-                              />
-                              <div className="absolute inset-0 flex items-center justify-center bg-Grey-900 opacity-0 transition-opacity duration-150 group-hover:opacity-90">
-                                <span className="Body_3_semibold text-Grey-50 text-center whitespace-pre-line">
-                                  {t("template.hoverText")}
-                                </span>
+                      <div className="grid grid-cols-5 gap-x-4 gap-y-6">
+                        {showSkeleton
+                          ? Array.from({ length: 15 }, (_, i) => (
+                              <div
+                                key={`skeleton-${i}`}
+                                className="w-[11rem] h-[11rem] rounded overflow-hidden"
+                              >
+                                <div className="w-full h-full bg-Grey-600 animate-pulse" />
                               </div>
-                            </div>
-                          ))}
-                    </div>
+                            ))
+                          : templates.map((template) => (
+                              <div
+                                key={template.templateId}
+                                tabIndex={0}
+                                role="button"
+                                className="w-[11rem] h-[11rem] relative aspect-square rounded overflow-hidden bg-Grey-200 group box-border border border-transparent hover:border-Red-400"
+                                onClick={() =>
+                                  handleTemplateClick(template.templateId)
+                                }
+                                onKeyDown={(e) =>
+                                  (e.key === "Enter" || e.key === " ") &&
+                                  handleTemplateClick(template.templateId)
+                                }
+                              >
+                                <Image
+                                  src={template.imageUrl}
+                                  alt={t("template.imageAlt", {
+                                    id: template.templateId,
+                                  })}
+                                  fill
+                                  className="object-cover"
+                                />
+                                <div className="absolute inset-0 flex items-center justify-center bg-Grey-900 opacity-0 transition-opacity duration-150 group-hover:opacity-90">
+                                  <span className="Body_3_semibold text-Grey-50 text-center whitespace-pre-line">
+                                    {t("template.hoverText")}
+                                  </span>
+                                </div>
+                              </div>
+                            ))}
+                      </div>
                     )}
                   </div>
                 </section>

--- a/src/app/[locale]/dashboard/page.tsx
+++ b/src/app/[locale]/dashboard/page.tsx
@@ -2,12 +2,14 @@
 
 import { useMemo, useState } from "react";
 import Image from "next/image";
+import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
 
 import DashboardCard from "@/components/dashboard/DashboardCard";
 import { DASHBOARD_CARDS } from "@/constants/dashboard/card";
 import Header from "@/components/dashboard/Header";
 import SideBar from "@/components/dashboard/sidebar/SideBar";
+import { PATHS, QUERY_KEYS } from "@/constants/common/paths";
 import { useTemplatesByCategory } from "@/hooks/queries/useTemplateApi";
 import { TemplateCategory } from "@/types/api/template.type";
 
@@ -15,6 +17,7 @@ const CATEGORY_MAP: TemplateCategory[] = ["STUDIO", "MODEL", "VIDEO"];
 
 const DashboardPage = () => {
   const t = useTranslations("dashboard");
+  const router = useRouter();
   const [hoverIndex, setHoverIndex] = useState<number | null>(null);
   const [pinnedIndex, setPinnedIndex] = useState<number | null>(null);
 
@@ -36,6 +39,16 @@ const DashboardPage = () => {
 
   const templates = data?.templates ?? [];
   const showSkeleton = isLoading;
+
+  const handleTemplateClick = (templateId: number) => {
+    if (activeIndex === null) return;
+    const mode = DASHBOARD_CARDS[activeIndex].key;
+    const params = new URLSearchParams({
+      [QUERY_KEYS.WORKBENCH_MODE]: mode,
+      [QUERY_KEYS.TEMPLATE_ID]: String(templateId),
+    });
+    router.push(`${PATHS.DASHBOARD_WORKBENCH}?${params.toString()}`);
+  };
 
   return (
     <main className="relative min-h-dvh w-full flex flex-col">
@@ -98,6 +111,8 @@ const DashboardPage = () => {
                               tabIndex={0}
                               role="button"
                               className="w-[11rem] h-[11rem] relative aspect-square rounded overflow-hidden bg-Grey-200 group box-border border border-transparent hover:border-Red-400"
+                              onClick={() => handleTemplateClick(template.templateId)}
+                              onKeyDown={(e) => e.key === "Enter" && handleTemplateClick(template.templateId)}
                             >
                               <Image
                                 src={template.imageUrl}

--- a/src/app/[locale]/dashboard/page.tsx
+++ b/src/app/[locale]/dashboard/page.tsx
@@ -35,7 +35,7 @@ const DashboardPage = () => {
   );
 
   const templates = data?.templates ?? [];
-  const showSkeleton = isLoading || templates.length === 0;
+  const showSkeleton = isLoading;
 
   return (
     <main className="relative min-h-dvh w-full flex flex-col">
@@ -77,6 +77,11 @@ const DashboardPage = () => {
                   </h2>
 
                   <div className="rounded-lg bg-Grey-800 py-6 px-[1.63rem]">
+                    {!isLoading && templates.length === 0 ? (
+                      <p className="text-Grey-400 Body_2_medium text-center py-10">
+                        {t("template.empty")}
+                      </p>
+                    ) : (
                     <div className="grid grid-cols-5 gap-x-4 gap-y-6">
                       {showSkeleton
                         ? Array.from({ length: 15 }, (_, i) => (
@@ -110,6 +115,7 @@ const DashboardPage = () => {
                             </div>
                           ))}
                     </div>
+                    )}
                   </div>
                 </section>
               )}

--- a/src/components/dashboard/workbench/background/BackgroundSwiper.tsx
+++ b/src/components/dashboard/workbench/background/BackgroundSwiper.tsx
@@ -22,6 +22,7 @@ interface BackgroundSwiperProps {
   items: BackgroundItem[];
   selectedId: string | null;
   onSelect: (id: string) => void;
+  isLoading?: boolean;
 }
 
 const BackgroundSwiper = ({
@@ -30,7 +31,10 @@ const BackgroundSwiper = ({
   items,
   selectedId,
   onSelect,
+  isLoading,
 }: BackgroundSwiperProps) => {
+  const showSkeleton = isLoading || items.length === 0;
+
   return (
     <section className="w-full flex flex-col gap-2">
       <h3 className="pl-9 Body_2_medium text-Grey-100">{title}</h3>
@@ -41,50 +45,64 @@ const BackgroundSwiper = ({
         </button>
 
         <div className="flex-1 w-[324px] min-w-0">
-          <Swiper
-            modules={[Navigation]}
-            slidesPerView={3}
-            slidesPerGroup={3}
-            spaceBetween={12}
-            loop
-            navigation={{
-              prevEl: `.swiper-prev-${id}`,
-              nextEl: `.swiper-next-${id}`,
-            }}
-          >
-            {items.map((item) => {
-              const isSelected = selectedId === item.id;
+          {showSkeleton ? (
+            <div className="flex gap-3">
+              {Array.from({ length: 3 }, (_, i) => (
+                <div
+                  key={i}
+                  className={clsx(
+                    "flex-1 h-[6.25rem] rounded bg-Grey-700",
+                    isLoading && "animate-pulse"
+                  )}
+                />
+              ))}
+            </div>
+          ) : (
+            <Swiper
+              modules={[Navigation]}
+              slidesPerView={3}
+              slidesPerGroup={3}
+              spaceBetween={12}
+              loop
+              navigation={{
+                prevEl: `.swiper-prev-${id}`,
+                nextEl: `.swiper-next-${id}`,
+              }}
+            >
+              {items.map((item) => {
+                const isSelected = selectedId === item.id;
 
-              return (
-                <SwiperSlide key={item.id}>
-                  <button
-                    type="button"
-                    onClick={() => onSelect(item.id)}
-                    className="w-full"
-                  >
-                    <div
-                      className={clsx(
-                        "relative w-full h-[6.25rem] rounded overflow-hidden",
-                        isSelected
-                          ? "bg-gradient-to-b from-Red-350 to-Red-500 p-[1.5px]"
-                          : "bg-Grey-800"
-                      )}
+                return (
+                  <SwiperSlide key={item.id}>
+                    <button
+                      type="button"
+                      onClick={() => onSelect(item.id)}
+                      className="w-full"
                     >
-                      <div className="relative w-full h-full rounded overflow-hidden bg-Grey-800">
-                        <Image
-                          src={item.src}
-                          alt={item.alt ?? ""}
-                          fill
-                          sizes="6.25rem"
-                          className="object-cover"
-                        />
+                      <div
+                        className={clsx(
+                          "relative w-full h-[6.25rem] rounded overflow-hidden",
+                          isSelected
+                            ? "bg-gradient-to-b from-Red-350 to-Red-500 p-[1.5px]"
+                            : "bg-Grey-800"
+                        )}
+                      >
+                        <div className="relative w-full h-full rounded overflow-hidden bg-Grey-800">
+                          <Image
+                            src={item.src}
+                            alt={item.alt ?? ""}
+                            fill
+                            sizes="6.25rem"
+                            className="object-cover"
+                          />
+                        </div>
                       </div>
-                    </div>
-                  </button>
-                </SwiperSlide>
-              );
-            })}
-          </Swiper>
+                    </button>
+                  </SwiperSlide>
+                );
+              })}
+            </Swiper>
+          )}
         </div>
 
         <button className={`swiper-next-${id}`} aria-label="다음">

--- a/src/components/dashboard/workbench/background/BackgroundSwiper.tsx
+++ b/src/components/dashboard/workbench/background/BackgroundSwiper.tsx
@@ -37,7 +37,13 @@ const BackgroundSwiper = ({
 
   return (
     <section className="w-full flex flex-col gap-2">
-      <h3 className="pl-9 Body_2_medium text-Grey-100">{title}</h3>
+      <h3 className="pl-9 Body_2_medium">
+        {isLoading ? (
+          <span className="inline-block w-20 h-[1em] rounded bg-Grey-700 animate-pulse" />
+        ) : (
+          <span className="text-Grey-100">{title}</span>
+        )}
+      </h3>
 
       <div className="relative items-center flex gap-3">
         <button className={`swiper-prev-${id}`} aria-label="이전">

--- a/src/components/dashboard/workbench/background/BackgroundSwiper.tsx
+++ b/src/components/dashboard/workbench/background/BackgroundSwiper.tsx
@@ -18,7 +18,7 @@ type BackgroundItem = {
 
 interface BackgroundSwiperProps {
   id: string;
-  title: string;
+  title?: string;
   items: BackgroundItem[];
   selectedId: string | null;
   onSelect: (id: string) => void;
@@ -37,13 +37,15 @@ const BackgroundSwiper = ({
 
   return (
     <section className="w-full flex flex-col gap-2">
-      <h3 className="pl-9 Body_2_medium">
-        {isLoading ? (
-          <span className="inline-block w-20 h-[1em] rounded bg-Grey-700 animate-pulse" />
-        ) : (
-          <span className="text-Grey-100">{title}</span>
-        )}
-      </h3>
+      {title !== undefined && (
+        <h3 className="pl-9 Body_2_medium">
+          {isLoading ? (
+            <span className="inline-block w-20 h-[1em] rounded bg-Grey-700 animate-pulse" />
+          ) : (
+            <span className="text-Grey-100">{title}</span>
+          )}
+        </h3>
+      )}
 
       <div className="relative items-center flex gap-3">
         <button className={`swiper-prev-${id}`} aria-label="이전">

--- a/src/components/dashboard/workbench/background/BackgroundSwiper.tsx
+++ b/src/components/dashboard/workbench/background/BackgroundSwiper.tsx
@@ -48,19 +48,21 @@ const BackgroundSwiper = ({
       )}
 
       <div className="relative items-center flex gap-3">
-        <button className={`swiper-prev-${id}`} aria-label="이전">
-          <Down className="rotate-90 h-6 w-6" />
-        </button>
+        {!showSkeleton && (
+          <button className={`swiper-prev-${id}`} aria-label="이전">
+            <Down className="rotate-90 h-6 w-6" />
+          </button>
+        )}
 
         <div className="flex-1 w-[324px] min-w-0">
           {showSkeleton ? (
-            <div className="flex gap-3">
+            <div className="flex gap-3 justify-center">
               {Array.from({ length: 3 }, (_, i) => (
                 <div
                   key={i}
                   className={clsx(
-                    "flex-1 h-[6.25rem] rounded bg-Grey-700",
-                    isLoading && "animate-pulse"
+                    "w-[6.25rem] h-[6.25rem] rounded bg-Grey-700",
+                    isLoading && "animate-pulse",
                   )}
                 />
               ))}
@@ -92,7 +94,7 @@ const BackgroundSwiper = ({
                           "relative w-full h-[6.25rem] rounded overflow-hidden",
                           isSelected
                             ? "bg-gradient-to-b from-Red-350 to-Red-500 p-[1.5px]"
-                            : "bg-Grey-800"
+                            : "bg-Grey-800",
                         )}
                       >
                         <div className="relative w-full h-full rounded overflow-hidden bg-Grey-800">
@@ -113,9 +115,11 @@ const BackgroundSwiper = ({
           )}
         </div>
 
-        <button className={`swiper-next-${id}`} aria-label="다음">
-          <Down className="-rotate-90 h-6 w-6" />
-        </button>
+        {!showSkeleton && (
+          <button className={`swiper-next-${id}`} aria-label="다음">
+            <Down className="-rotate-90 h-6 w-6" />
+          </button>
+        )}
       </div>
     </section>
   );

--- a/src/components/dashboard/workbench/background/BackgroundTab.tsx
+++ b/src/components/dashboard/workbench/background/BackgroundTab.tsx
@@ -9,7 +9,7 @@ import BackgroundSwiper from "./BackgroundSwiper";
 import SearchBar from "./SearchBar";
 import ProductImageRequiredModal from "./ProductImageRequiredModal";
 import GlassButton from "@/components/common/GlassButton";
-import { useTemplatesByKeyword } from "@/hooks/queries/useTemplateApi";
+import { useTemplateKeywords, useTemplatesByKeyword } from "@/hooks/queries/useTemplateApi";
 import { TEMPLATE_KEYWORDS } from "@/constants/dashboard/template";
 import { TemplateKeyword } from "@/types/api/template.type";
 
@@ -29,17 +29,19 @@ const BackgroundTab = ({ uploadedImage }: BackgroundTabProps) => {
 
   const [isProductImageModalOpen, setIsProductImageModalOpen] = useState(false);
 
-  const { data, isLoading } = useTemplatesByKeyword({
+  const { data: keywords, isLoading: isKeywordsLoading } = useTemplateKeywords();
+  const { data: templatesData, isLoading: isTemplatesLoading } = useTemplatesByKeyword({
     keywords: TEMPLATE_KEYWORDS,
     limitPerKeyword: 9,
   });
 
-  const findTemplates = (keyword: TemplateKeyword) =>
-    toItems(data?.find((g) => g.keyword === keyword)?.templates ?? []);
+  const isLoading = isKeywordsLoading || isTemplatesLoading;
 
-  const displayBackgrounds = findTemplates("GENERAL_DISPLAY");
-  const fabricBackgrounds = findTemplates("FABRIC_VELVET");
-  const outdoorBackgrounds = findTemplates("OUTDOOR");
+  const findTemplates = (keyword: TemplateKeyword) =>
+    toItems(templatesData?.find((g) => g.keyword === keyword)?.templates ?? []);
+
+  const getTitle = (keyword: TemplateKeyword) =>
+    keywords?.find((k) => k.keyword === keyword)?.title ?? "";
 
   const handleClickGenerate = () => {
     if (!uploadedImage) {
@@ -66,30 +68,17 @@ const BackgroundTab = ({ uploadedImage }: BackgroundTabProps) => {
           isSearching ? "h-[413px]" : "h-[452px]"
         )}
       >
-        <BackgroundSwiper
-          id="display"
-          title={t("categories.display")}
-          items={displayBackgrounds}
-          selectedId={selectedBackgroundId}
-          onSelect={setSelectedBackgroundId}
-          isLoading={isLoading}
-        />
-        <BackgroundSwiper
-          id="fabric"
-          title={t("categories.fabric")}
-          items={fabricBackgrounds}
-          selectedId={selectedBackgroundId}
-          onSelect={setSelectedBackgroundId}
-          isLoading={isLoading}
-        />
-        <BackgroundSwiper
-          id="outdoor"
-          title={t("categories.outdoor")}
-          items={outdoorBackgrounds}
-          selectedId={selectedBackgroundId}
-          onSelect={setSelectedBackgroundId}
-          isLoading={isLoading}
-        />
+        {TEMPLATE_KEYWORDS.map((keyword) => (
+          <BackgroundSwiper
+            key={keyword}
+            id={keyword}
+            title={getTitle(keyword)}
+            items={findTemplates(keyword)}
+            selectedId={selectedBackgroundId}
+            onSelect={setSelectedBackgroundId}
+            isLoading={isLoading}
+          />
+        ))}
       </div>
 
       <div className="flex items-center justify-center gap-4 mt-6 Body_2_semibold">

--- a/src/components/dashboard/workbench/background/BackgroundTab.tsx
+++ b/src/components/dashboard/workbench/background/BackgroundTab.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import clsx from "clsx";
 import { useTranslations } from "next-intl";
 import { Plus } from "@/assets/icons";
@@ -9,7 +9,7 @@ import BackgroundSwiper from "./BackgroundSwiper";
 import SearchBar from "./SearchBar";
 import ProductImageRequiredModal from "./ProductImageRequiredModal";
 import GlassButton from "@/components/common/GlassButton";
-import { useTemplateKeywords, useTemplatesByKeyword } from "@/hooks/queries/useTemplateApi";
+import { useTemplateKeywords, useTemplatesByKeyword, useSearchTemplates } from "@/hooks/queries/useTemplateApi";
 import { TEMPLATE_KEYWORDS } from "@/constants/dashboard/template";
 import { TemplateKeyword } from "@/types/api/template.type";
 
@@ -23,6 +23,7 @@ const toItems = (templates: { templateId: number; imageObjectKey: string }[]) =>
 const BackgroundTab = ({ uploadedImage }: BackgroundTabProps) => {
   const t = useTranslations("dashboard.workbench.backgroundTab");
   const [isSearching, setIsSearching] = useState(false);
+  const [searchKeyword, setSearchKeyword] = useState("");
   const [selectedBackgroundId, setSelectedBackgroundId] = useState<
     string | null
   >(null);
@@ -34,6 +35,14 @@ const BackgroundTab = ({ uploadedImage }: BackgroundTabProps) => {
     keywords: TEMPLATE_KEYWORDS,
     limitPerKeyword: 9,
   });
+  const { data: searchResults, isLoading: isSearchLoading } = useSearchTemplates(
+    { keyword: searchKeyword },
+    !!searchKeyword,
+  );
+
+  useEffect(() => {
+    if (!isSearching) setSearchKeyword("");
+  }, [isSearching]);
 
   const isLoading = isKeywordsLoading || isTemplatesLoading;
 
@@ -57,9 +66,7 @@ const BackgroundTab = ({ uploadedImage }: BackgroundTabProps) => {
       <SearchBar
         isSearching={isSearching}
         setIsSearching={setIsSearching}
-        onSearch={(keyword) => {
-          console.log("검색어:", keyword);
-        }}
+        onSearch={setSearchKeyword}
       />
 
       <div
@@ -68,17 +75,33 @@ const BackgroundTab = ({ uploadedImage }: BackgroundTabProps) => {
           isSearching ? "h-[413px]" : "h-[452px]"
         )}
       >
-        {TEMPLATE_KEYWORDS.map((keyword) => (
-          <BackgroundSwiper
-            key={keyword}
-            id={keyword}
-            title={getTitle(keyword)}
-            items={findTemplates(keyword)}
-            selectedId={selectedBackgroundId}
-            onSelect={setSelectedBackgroundId}
-            isLoading={isLoading}
-          />
-        ))}
+        {searchKeyword ? (
+          isSearchLoading || (searchResults && searchResults.length > 0) ? (
+            <BackgroundSwiper
+              id="search"
+              items={toItems(searchResults ?? [])}
+              selectedId={selectedBackgroundId}
+              onSelect={setSelectedBackgroundId}
+              isLoading={isSearchLoading}
+            />
+          ) : (
+            <p className="flex items-center justify-center h-full Body_3_medium text-Grey-500">
+              {t("noSearchResults")}
+            </p>
+          )
+        ) : (
+          TEMPLATE_KEYWORDS.map((keyword) => (
+            <BackgroundSwiper
+              key={keyword}
+              id={keyword}
+              title={getTitle(keyword)}
+              items={findTemplates(keyword)}
+              selectedId={selectedBackgroundId}
+              onSelect={setSelectedBackgroundId}
+              isLoading={isLoading}
+            />
+          ))
+        )}
       </div>
 
       <div className="flex items-center justify-center gap-4 mt-6 Body_2_semibold">

--- a/src/components/dashboard/workbench/background/BackgroundTab.tsx
+++ b/src/components/dashboard/workbench/background/BackgroundTab.tsx
@@ -9,10 +9,16 @@ import BackgroundSwiper from "./BackgroundSwiper";
 import SearchBar from "./SearchBar";
 import ProductImageRequiredModal from "./ProductImageRequiredModal";
 import GlassButton from "@/components/common/GlassButton";
+import { useTemplatesByKeyword } from "@/hooks/queries/useTemplateApi";
+import { TEMPLATE_KEYWORDS } from "@/constants/dashboard/template";
+import { TemplateKeyword } from "@/types/api/template.type";
 
 interface BackgroundTabProps {
   uploadedImage: File | null;
 }
+
+const toItems = (templates: { templateId: number; imageObjectKey: string }[]) =>
+  templates.map((t) => ({ id: String(t.templateId), src: t.imageObjectKey }));
 
 const BackgroundTab = ({ uploadedImage }: BackgroundTabProps) => {
   const t = useTranslations("dashboard.workbench.backgroundTab");
@@ -23,20 +29,17 @@ const BackgroundTab = ({ uploadedImage }: BackgroundTabProps) => {
 
   const [isProductImageModalOpen, setIsProductImageModalOpen] = useState(false);
 
-  const displayBackgrounds = Array.from({ length: 6 }, (_, idx) => ({
-    id: `display-${idx}`,
-    src: "/images/landing/product1.png",
-  }));
+  const { data, isLoading } = useTemplatesByKeyword({
+    keywords: TEMPLATE_KEYWORDS,
+    limitPerKeyword: 9,
+  });
 
-  const fabricBackgrounds = Array.from({ length: 6 }, (_, idx) => ({
-    id: `fabric-${idx}`,
-    src: "/images/landing/product2.png",
-  }));
+  const findTemplates = (keyword: TemplateKeyword) =>
+    toItems(data?.find((g) => g.keyword === keyword)?.templates ?? []);
 
-  const outdoorBackgrounds = Array.from({ length: 6 }, (_, idx) => ({
-    id: `outdoor-${idx}`,
-    src: "/images/landing/product3.png",
-  }));
+  const displayBackgrounds = findTemplates("GENERAL_DISPLAY");
+  const fabricBackgrounds = findTemplates("FABRIC_VELVET");
+  const outdoorBackgrounds = findTemplates("OUTDOOR");
 
   const handleClickGenerate = () => {
     if (!uploadedImage) {
@@ -69,6 +72,7 @@ const BackgroundTab = ({ uploadedImage }: BackgroundTabProps) => {
           items={displayBackgrounds}
           selectedId={selectedBackgroundId}
           onSelect={setSelectedBackgroundId}
+          isLoading={isLoading}
         />
         <BackgroundSwiper
           id="fabric"
@@ -76,6 +80,7 @@ const BackgroundTab = ({ uploadedImage }: BackgroundTabProps) => {
           items={fabricBackgrounds}
           selectedId={selectedBackgroundId}
           onSelect={setSelectedBackgroundId}
+          isLoading={isLoading}
         />
         <BackgroundSwiper
           id="outdoor"
@@ -83,6 +88,7 @@ const BackgroundTab = ({ uploadedImage }: BackgroundTabProps) => {
           items={outdoorBackgrounds}
           selectedId={selectedBackgroundId}
           onSelect={setSelectedBackgroundId}
+          isLoading={isLoading}
         />
       </div>
 

--- a/src/components/dashboard/workbench/background/SearchBar.tsx
+++ b/src/components/dashboard/workbench/background/SearchBar.tsx
@@ -47,9 +47,15 @@ const SearchBar = ({
   );
 
   useEffect(() => {
-    if (!isSearching || !keyword.trim()) return;
+    if (!isSearching) return;
 
     clearTimer();
+
+    if (!keyword.trim()) {
+      onSearch("");
+      return;
+    }
+
     timerRef.current = setTimeout(() => {
       onSearch(keyword.trim());
     }, DEBOUNCE_MS);

--- a/src/constants/common/paths.ts
+++ b/src/constants/common/paths.ts
@@ -29,6 +29,7 @@ export const LANDING_SECTION_HASH = {
 export const QUERY_KEYS = {
   WORKBENCH_MODE: "mode",
   PORTFOLIO_CATEGORY: "category",
+  TEMPLATE_ID: "templateId",
 } as const;
 
 export const PORTFOLIO_CATEGORY = {

--- a/src/constants/dashboard/template.ts
+++ b/src/constants/dashboard/template.ts
@@ -1,0 +1,7 @@
+import { TemplateKeyword } from "@/types/api/template.type";
+
+export const TEMPLATE_KEYWORDS: TemplateKeyword[] = [
+  "GENERAL_DISPLAY",
+  "FABRIC_VELVET",
+  "OUTDOOR",
+];

--- a/src/hooks/queries/queryKeys.ts
+++ b/src/hooks/queries/queryKeys.ts
@@ -1,6 +1,7 @@
 import {
   GetTemplatesByCategoryParams,
   GetTemplatesByKeywordParams,
+  SearchTemplatesParams,
 } from "@/types/api/template.type";
 
 export const queryKeys = {
@@ -14,6 +15,13 @@ export const queryKeys = {
     category: () => [...queryKeys.templates.all, "category"] as const,
     categoryList: (params: GetTemplatesByCategoryParams) =>
       [...queryKeys.templates.category(), params] as const,
+
+    search: () => [...queryKeys.templates.all, "search"] as const,
+    searchList: (params: SearchTemplatesParams) =>
+      [...queryKeys.templates.search(), params] as const,
+
+    templateKeywords: () =>
+      [...queryKeys.templates.all, "templateKeywords"] as const,
   },
 
   mypage: {

--- a/src/hooks/queries/useMypageApi.ts
+++ b/src/hooks/queries/useMypageApi.ts
@@ -13,6 +13,7 @@ export const useMypage = () =>
   useQuery({
     queryKey: queryKeys.mypage.detail(),
     queryFn: getMypage,
+    retry: false,
   });
 
 export const useUpdateUsername = () =>

--- a/src/hooks/queries/useTemplateApi.ts
+++ b/src/hooks/queries/useTemplateApi.ts
@@ -3,12 +3,15 @@ import { useQuery } from "@tanstack/react-query";
 import {
   getTemplatesByCategory,
   getTemplatesByKeyword,
+  getSearchTemplates,
+  getTemplateKeywords,
 } from "@/apis/templateApi";
 
 import { queryKeys } from "./queryKeys";
 import {
   GetTemplatesByCategoryParams,
   GetTemplatesByKeywordParams,
+  SearchTemplatesParams,
 } from "@/types/api/template.type";
 
 export const useTemplatesByKeyword = (params: GetTemplatesByKeywordParams) =>
@@ -25,4 +28,16 @@ export const useTemplatesByCategory = (
     queryKey: queryKeys.templates.categoryList(params),
     queryFn: () => getTemplatesByCategory(params),
     enabled,
+  });
+
+export const useSearchTemplates = (params: SearchTemplatesParams) =>
+  useQuery({
+    queryKey: queryKeys.templates.searchList(params),
+    queryFn: () => getSearchTemplates(params),
+  });
+
+export const useTemplateKeywords = () =>
+  useQuery({
+    queryKey: queryKeys.templates.templateKeywords(),
+    queryFn: () => getTemplateKeywords(),
   });

--- a/src/hooks/queries/useTemplateApi.ts
+++ b/src/hooks/queries/useTemplateApi.ts
@@ -30,10 +30,14 @@ export const useTemplatesByCategory = (
     enabled,
   });
 
-export const useSearchTemplates = (params: SearchTemplatesParams) =>
+export const useSearchTemplates = (
+  params: SearchTemplatesParams,
+  enabled: boolean = true,
+) =>
   useQuery({
     queryKey: queryKeys.templates.searchList(params),
     queryFn: () => getSearchTemplates(params),
+    enabled,
   });
 
 export const useTemplateKeywords = () =>

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -6,7 +6,13 @@ import { routing } from "./i18n/routing";
 const handleI18nRouting = createIntlMiddleware(routing);
 
 // [locale] 폴더 안에 실제로 존재하는 페이지들
-const localePages = ["signup", "dashboard", "mypage", "login"];
+const localePages = [
+  "signup",
+  "dashboard",
+  "mypage",
+  "login",
+  "password-reset",
+];
 
 export default function proxy(request: NextRequest) {
   const { pathname } = request.nextUrl;

--- a/src/types/api/template.type.ts
+++ b/src/types/api/template.type.ts
@@ -9,7 +9,7 @@ export type TemplateCategory = "MODEL" | "STUDIO" | "IMAGE" | "VIDEO";
 // 키워드 기준 템플릿 아이템
 export interface TemplateItem {
   templateId: number;
-  keywordType: TemplateKeyword
+  keywordType: TemplateKeyword;
   imageObjectKey: string;
   category: TemplateCategory;
   keywordTitle: string;
@@ -46,13 +46,7 @@ export interface GetTemplatesByCategoryResponse {
 }
 
 // 템플릿 검색 아이템
-export interface TemplateSearchItem {
-  templateId: number;
-  keywordType: TemplateKeyword;
-  imageObjectKey: string;
-  category: TemplateCategory;
-  keywordTitle: string;
-}
+export type TemplateSearchItem = TemplateItem;
 
 // 템플릿 검색
 export interface SearchTemplatesParams {

--- a/src/types/api/template.type.ts
+++ b/src/types/api/template.type.ts
@@ -44,3 +44,27 @@ export interface GetTemplatesByCategoryResponse {
   templates: TemplateCategoryItem[];
   pageInfo: PageInfo;
 }
+
+// 템플릿 검색 아이템
+export interface TemplateSearchItem {
+  templateId: number;
+  keywordType: TemplateKeyword;
+  imageObjectKey: string;
+  category: TemplateCategory;
+  keywordTitle: string;
+}
+
+// 템플릿 검색
+export interface SearchTemplatesParams {
+  keyword: string;
+}
+
+export type SearchTemplatesResponse = TemplateSearchItem[];
+
+// 템플릿 키워드 목록 아이템
+export interface TemplateKeywordItem {
+  keyword: TemplateKeyword;
+  title: string;
+}
+
+export type GetTemplateKeywordsResponse = TemplateKeywordItem[];

--- a/src/types/api/template.type.ts
+++ b/src/types/api/template.type.ts
@@ -9,10 +9,10 @@ export type TemplateCategory = "MODEL" | "STUDIO" | "IMAGE" | "VIDEO";
 // 키워드 기준 템플릿 아이템
 export interface TemplateItem {
   templateId: number;
-  keyword: TemplateKeyword;
-  keywordTitle: string;
-  imageUrl: string;
+  keywordType: TemplateKeyword
+  imageObjectKey: string;
   category: TemplateCategory;
+  keywordTitle: string;
 }
 
 // 카테고리 기준 템플릿 아이템
@@ -23,14 +23,14 @@ export interface TemplateCategoryItem {
 
 // 키워드 기준 템플릿 조회
 export interface GetTemplatesByKeywordParams {
-  keyword: TemplateKeyword;
-  pageNum: number;
-  limit: number;
+  keywords: TemplateKeyword[];
+  limitPerKeyword: number;
 }
 
 export interface GetTemplatesByKeywordResponse {
+  keyword: TemplateKeyword;
+  keywordTitle: string;
   templates: TemplateItem[];
-  pageInfo: PageInfo;
 }
 
 // 카테고리 기준 템플릿 조회


### PR DESCRIPTION
## 💡 PR 타입

- [x] 기능 추가
- [ ] 버그 수정
- [x] 코드 개선
- [ ] 문서 수정
- [ ] 기타

## 📝 PR 내용
- 템플릿 도메인 API 함수/ 타입을 추가 및 수정했습니다.
- 키워드 기반 템플릿 이미지 조회 API를 연동하여, 실제 서버 데이터를 기반으로 템플릿 이미지를 불러오도록 구현했습니다. (`GET /templates/keyword`)
- 기존의 키워드 고정(mock) 방식에서 벗어나, 키워드 조회 API를 통해 동적으로 데이터를 받아오는 구조로 리팩토링했습니다. (`GET /templates/template-keywords`)
- 템플릿 검색 API를 연동하여, 검색어 기반 템플릿 조회가 가능하도록 구현했습니다. 검색어가 없을 경우, 기존 키워드 기반 템플릿이 보여집니다. `GET /templates/search`)
- `/dashboard` 페이지에서 템플릿이 존재하지 않는 경우, 기존 스켈레톤 UI 대신 안내 텍스트가 표시되도록 수정하여 UX를 개선했습니다.
- `/dashboard`에서 특정 모드의 예시 템플릿을 선택하면 templateId를 쿼리로 함께 전달하여 `/dashboard/workbench?mode=video`와 같은 형태로 이동하도록 구현했습니다.

## 🔍 관련 이슈

- closes #52 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 출시 노트

* **새 기능**
  * 템플릿 검색 기능 추가 및 검색 결과 표시
  * 빈 상태 문구(템플릿 없음/검색 결과 없음) 추가

* **개선사항**
  * 템플릿 선택 시 워크벤치로 자동 이동(마우스 및 키보드 지원)
  * 키워드 기반 동적 템플릿 로딩 및 로딩 스켈레톤 표시
  * 검색 입력 처리 개선으로 즉시 빈 검색 처리 및 일관된 로딩 표시
<!-- end of auto-generated comment: release notes by coderabbit.ai -->