### PR TITLE
[Feat] 이미지 누끼 기능 및 합성 플로우 API 연동

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -43,7 +43,9 @@
     "error": {
       "emailSendFailed": {
         "title": "Failed to send email",
-        "description": "We couldn't send the email.\nPlease try again or contact support."
+        "description": "We’re having trouble sending the email right now.\nPlease try again in a moment,",
+        "contact": "or contact us if the issue persists:",
+        "contactEmail": "studiox.co.kr@gmail.com"
       },
       "emailAlreadyRegistered": {
         "title": "Email already registered",

--- a/messages/en.json
+++ b/messages/en.json
@@ -144,6 +144,11 @@
       "hoverText": "Generate image\nwith this background",
       "empty": "No templates available"
     },
+    "sidebar": {
+      "createButton": "Create",
+      "newProject": "Start New Project",
+      "continueProject": "Continue Project"
+    },
     "create": {
       "badge": "Start New Project",
       "title": "Choose the task you want.",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -144,6 +144,11 @@
       "hoverText": "이 배경으로\n이미지 생성하기",
       "empty": "사용 가능한 템플릿이 없습니다"
     },
+    "sidebar": {
+      "createButton": "생성하기",
+      "newProject": "새 프로젝트 시작하기",
+      "continueProject": "프로젝트 이어하기"
+    },
     "create": {
       "badge": "새 프로젝트 시작하기",
       "title": "원하는 작업을 선택해 주세요",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -43,7 +43,9 @@
     "error": {
       "emailSendFailed": {
         "title": "이메일 전송에 실패했습니다",
-        "description": "일시적인 오류로 이메일을 보내지 못했어요.\n잠시 후 다시 시도하거나,\n문제가 계속되면 고객센터로 문의해 주세요."
+        "description": "일시적인 오류로 이메일을 보내지 못했어요.\n잠시 후 다시 시도하거나,",
+        "contact": "문제가 계속되면 아래로 문의해 주세요:",
+        "contactEmail": "studiox.co.kr@gmail.com"
       },
       "emailAlreadyRegistered": {
         "title": "이미 가입된 이메일입니다",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6438,6 +6438,17 @@
         }
       }
     },
+    "node_modules/next-intl/node_modules/@swc/helpers": {
+      "version": "0.5.19",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.19.tgz",
+      "integrity": "sha512-QamiFeIK3txNjgUTNppE6MiG3p7TdninpZu0E0PbqVh1a9FNLT2FRhisaa4NcaX52XVhA5l7Pk58Ft7Sqi/2sA==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
     "node_modules/next/node_modules/postcss": {
       "version": "8.4.31",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",

--- a/src/apis/axios.ts
+++ b/src/apis/axios.ts
@@ -30,7 +30,8 @@ axiosInstance.interceptors.response.use(
       !window.location.pathname.includes(PATHS.SIGNUP) &&
       !window.location.pathname.includes(PATHS.PASSWORD_RESET)
     ) {
-      window.location.href = PATHS.LOGIN;
+      const callbackUrl = encodeURIComponent(window.location.pathname + window.location.search);
+      window.location.href = `${PATHS.LOGIN}?callbackUrl=${callbackUrl}`;
     }
     return Promise.reject(error);
   },

--- a/src/apis/axios.ts
+++ b/src/apis/axios.ts
@@ -24,7 +24,12 @@ axiosInstance.interceptors.response.use(
     return response;
   },
   (error) => {
-    if (error.response?.status === 403 && !window.location.pathname.includes(PATHS.LOGIN)) {
+    if (
+      error.response?.status === 403 &&
+      !window.location.pathname.includes(PATHS.LOGIN) &&
+      !window.location.pathname.includes(PATHS.SIGNUP) &&
+      !window.location.pathname.includes(PATHS.PASSWORD_RESET)
+    ) {
       window.location.href = PATHS.LOGIN;
     }
     return Promise.reject(error);

--- a/src/apis/folderApi.ts
+++ b/src/apis/folderApi.ts
@@ -1,7 +1,14 @@
 import { axiosInstance } from "@/apis/axios";
-import { GetFoldersResponse } from "@/types/api/folder.type";
+import { GetFoldersResponse, GetFolderDetailResponse, GetFolderDetailParams } from "@/types/api/folder.type";
 
 export const getFolders = async (): Promise<GetFoldersResponse> => {
   const response = await axiosInstance.get<GetFoldersResponse>("/folder");
+  return response.data;
+};
+
+export const getFolderDetail = async ({ folderId, pageNum, limit, sort = "DESC" }: GetFolderDetailParams): Promise<GetFolderDetailResponse> => {
+  const response = await axiosInstance.get<GetFolderDetailResponse>(`/folder/${folderId}`, {
+    params: { pageNum, limit, sort },
+  });
   return response.data;
 };

--- a/src/apis/folderApi.ts
+++ b/src/apis/folderApi.ts
@@ -1,0 +1,7 @@
+import { axiosInstance } from "@/apis/axios";
+import { GetFoldersResponse } from "@/types/api/folder.type";
+
+export const getFolders = async (): Promise<GetFoldersResponse> => {
+  const response = await axiosInstance.get<GetFoldersResponse>("/folder");
+  return response.data;
+};

--- a/src/apis/imageApi.ts
+++ b/src/apis/imageApi.ts
@@ -10,8 +10,7 @@ import {
 
 export const getRawPresign = async (): Promise<GetRawPresignResponse> => {
   const response =
-    await axiosInstance.get<GetRawPresignResponse>("/image/raw/presign");
-
+    await axiosInstance.get<GetRawPresignResponse>("/s3/presign/raw")
   return response.data;
 };
 

--- a/src/apis/imageApi.ts
+++ b/src/apis/imageApi.ts
@@ -1,0 +1,43 @@
+import { axiosInstance } from "@/apis/axios";
+import {
+  PostCutoutImageRequest,
+  PostCutoutImageResponse,
+  PostImageRequest,
+  PostImageResponse,
+  GetImageResponse,
+  GetRawPresignResponse,
+} from "@/types/api/image.type";
+
+export const getRawPresign = async (): Promise<GetRawPresignResponse> => {
+  const response =
+    await axiosInstance.get<GetRawPresignResponse>("/image/raw/presign");
+
+  return response.data;
+};
+
+export const postCutoutImage = async (
+  body: PostCutoutImageRequest,
+): Promise<PostCutoutImageResponse> => {
+  const response = await axiosInstance.post<PostCutoutImageResponse>(
+    "/image/cutout",
+    body,
+  );
+
+  return response.data;
+};
+
+export const postImage = async (
+  body: PostImageRequest,
+): Promise<PostImageResponse> => {
+  const response = await axiosInstance.post<PostImageResponse>("/image", body);
+
+  return response.data;
+};
+
+export const getImage = async (imageId: number): Promise<GetImageResponse> => {
+  const response = await axiosInstance.get<GetImageResponse>(
+    `/image/${imageId}`,
+  );
+
+  return response.data;
+};

--- a/src/app/[locale]/dashboard/continue/page.tsx
+++ b/src/app/[locale]/dashboard/continue/page.tsx
@@ -29,7 +29,7 @@ const ContinuePage = () => {
         <Back className="w-11 h-11" />
       </button>
 
-      <main className="w-full flex flex-col items-center gap-[4.5rem] flex-1 mt-[8.25rem] mb-[6.75rem]">
+      <main className="w-full flex flex-col items-center gap-[4.5rem] flex-1 mt-[3.25rem] mb-[6.75rem]">
         <div className="flex flex-col gap-3 items-center">
           <span className="py-2 px-5 border border-Grey-700 bg-[rgba(255,255,255,0.03)] Body_2_medium text-Grey-100 rounded-[5rem]">
             {t("continue.badge")}

--- a/src/app/[locale]/dashboard/create/page.tsx
+++ b/src/app/[locale]/dashboard/create/page.tsx
@@ -4,7 +4,8 @@ import { Back } from "@/assets/icons";
 import DashboardCard from "@/components/dashboard/DashboardCard";
 import Header from "@/components/dashboard/Header";
 import { DASHBOARD_CARDS } from "@/constants/dashboard/card";
-import { useRouter } from "next/navigation";
+import { PATHS, QUERY_KEYS } from "@/constants/common/paths";
+import { useRouter } from "@/i18n/routing";
 import { useTranslations } from "next-intl";
 
 const CreatePage = () => {
@@ -43,6 +44,11 @@ const CreatePage = () => {
                   title={t(`cards.${card.key}.title`)}
                   content={t(`cards.${card.key}.content`)}
                   mediaSrc={card.mediaSrc}
+                  onClick={() =>
+                    router.push(
+                      `${PATHS.DASHBOARD_WORKBENCH}?${QUERY_KEYS.WORKBENCH_MODE}=${card.key}`,
+                    )
+                  }
                 />
               </li>
             ))}

--- a/src/app/[locale]/login/page.tsx
+++ b/src/app/[locale]/login/page.tsx
@@ -2,7 +2,7 @@
 
 import { Close } from "@/assets/icons";
 import LoginInput from "@/components/login/LoginInput";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { useState } from "react";
 import { PATHS } from "@/constants/common/paths";
 import Header from "@/components/dashboard/Header";
@@ -16,6 +16,7 @@ export default function Login() {
   const [password, setPassword] = useState("");
   const [isPasswordOpen, setIsPasswordOpen] = useState(false);
   const router = useRouter();
+  const searchParams = useSearchParams();
   const t = useTranslations("login");
   const { mutate: login, isPending } = useLogin();
 
@@ -31,7 +32,8 @@ export default function Login() {
       { email, password },
       {
         onSuccess: () => {
-          router.push(PATHS.DASHBOARD);
+          const callbackUrl = searchParams.get("callbackUrl");
+          router.push(callbackUrl ?? PATHS.DASHBOARD);
         },
       },
     );

--- a/src/app/[locale]/login/page.tsx
+++ b/src/app/[locale]/login/page.tsx
@@ -10,6 +10,7 @@ import GlassButton from "@/components/common/GlassButton";
 import { useTranslations } from "next-intl";
 import { useLogin } from "@/hooks/queries/useAuthApi";
 import GoogleLoginButton from "@/components/login/GoogleLoginButton";
+import { getSafeCallbackDestination } from "@/utils/authUtils";
 
 export default function Login() {
   const [email, setEmail] = useState("");
@@ -33,7 +34,7 @@ export default function Login() {
       {
         onSuccess: () => {
           const callbackUrl = searchParams.get("callbackUrl");
-          router.push(callbackUrl ?? PATHS.DASHBOARD);
+          router.push(getSafeCallbackDestination(callbackUrl, PATHS.DASHBOARD));
         },
       },
     );

--- a/src/app/[locale]/mypage/page.tsx
+++ b/src/app/[locale]/mypage/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Header from "@/components/dashboard/Header";
-import SideBar from "@/components/dashboard/SideBar";
+import SideBar from "@/components/dashboard/sidebar/SideBar";
 import { useState } from "react";
 import MyPageTabs from "@/components/mypage/MyPageTabs";
 import SettingsContent from "@/components/mypage/SettingsContent";

--- a/src/components/common/AlertModal.tsx
+++ b/src/components/common/AlertModal.tsx
@@ -13,7 +13,7 @@ interface AlertModalProps {
   isOpen: boolean;
   onClose: () => void;
   title: string;
-  description: ReactNode;
+  description: ReactNode | ReactNode[];
   buttons: AlertModalButton[];
   contained?: boolean;
 }
@@ -44,7 +44,7 @@ const AlertModal = ({
   if (!isOpen) return null;
   
   const modalContent = (
-    <div className="flex flex-col items-start gap-2.5 pb-9 px-11 relative bg-[#272b33e6] rounded-[0.5rem] backdrop-blur-sm shadow-[0_0_12px_0_rgba(8,8,8,0.25)]">
+    <div className="flex flex-col items-start gap-3 pb-9 px-11 relative bg-Grey-700/90 rounded-[0.5rem] backdrop-blur-sm shadow-[0_0_12px_0_rgba(8,8,8,0.25)]">
       <header className="flex items-start justify-between pt-7 self-stretch w-full">
         <h2
           id="modal-title"
@@ -67,12 +67,22 @@ const AlertModal = ({
         <div className="flex flex-col items-start gap-4 self-stretch w-full relative flex-[0_0_auto]">
           <div className="w-full h-[0.0625rem] bg-Grey-600" />
 
-          <p
-            id="modal-description"
-            className="self-stretch text-Grey-300 Body_1_medium whitespace-pre-line"
-          >
-            {description}
-          </p>
+          {Array.isArray(description) ? (
+            <div id="modal-description" className="flex flex-col gap-3 self-stretch">
+              {description.map((desc, i) => (
+                <p key={i} className="text-Grey-300 Body_1_medium whitespace-pre-line">
+                  {desc}
+                </p>
+              ))}
+            </div>
+          ) : (
+            <p
+              id="modal-description"
+              className="self-stretch text-Grey-300 Body_1_medium whitespace-pre-line"
+            >
+              {description}
+            </p>
+          )}
         </div>
 
         <div className="flex items-center gap-3 self-stretch w-full Body_2_semibold">

--- a/src/components/common/MobileModal.tsx
+++ b/src/components/common/MobileModal.tsx
@@ -48,6 +48,7 @@ const MobileModal = () => {
             height={166}
             className="w-full h-auto"
             priority
+            unoptimized
           />
         </div>
       </div>

--- a/src/components/dashboard/DashboardCard.tsx
+++ b/src/components/dashboard/DashboardCard.tsx
@@ -6,6 +6,7 @@ interface DashboardCardProps {
   content: string;
   mediaSrc: string;
   isActive?: boolean;
+  onClick?: () => void;
 }
 
 const DashboardCard = ({
@@ -13,6 +14,7 @@ const DashboardCard = ({
   content,
   mediaSrc,
   isActive,
+  onClick,
 }: DashboardCardProps) => {
   const isVideo = (src: string) => /\.(mp4|webm|ogg)$/i.test(src);
 
@@ -20,6 +22,8 @@ const DashboardCard = ({
     <div
       role="button"
       tabIndex={0}
+      onClick={onClick}
+      onKeyDown={(e) => e.key === "Enter" && onClick?.()}
       className={clsx(
         "h-[12.5rem] w-[19.25rem] group rounded bg-gradient-to-b p-px cursor-pointer",
         {

--- a/src/components/dashboard/DashboardCard.tsx
+++ b/src/components/dashboard/DashboardCard.tsx
@@ -17,20 +17,28 @@ const DashboardCard = ({
   onClick,
 }: DashboardCardProps) => {
   const isVideo = (src: string) => /\.(mp4|webm|ogg)$/i.test(src);
+  const isInteractive = Boolean(onClick);
 
   return (
     <div
-      role="button"
-      tabIndex={0}
+      role={isInteractive ? "button" : undefined}
+      tabIndex={isInteractive ? 0 : -1}
       onClick={onClick}
-      onKeyDown={(e) => e.key === "Enter" && onClick?.()}
+      onKeyDown={(e) => {
+        if (!isInteractive) return;
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          onClick?.();
+        }
+      }}
       className={clsx(
-        "h-[12.5rem] w-[19.25rem] group rounded bg-gradient-to-b p-px cursor-pointer",
+        "h-[12.5rem] w-[19.25rem] group rounded bg-gradient-to-b p-px",
+        isInteractive && "cursor-pointer",
         {
           "from-Grey-300 to-Grey-700 hover:from-Red-350 hover:to-Red-500":
             !isActive,
           "from-Red-350 to-Red-500": isActive,
-        }
+        },
       )}
     >
       <div className="h-full w-full rounded bg-Grey-800 overflow-hidden flex gap-4">
@@ -39,7 +47,7 @@ const DashboardCard = ({
             className={clsx(
               "whitespace-pre-line",
               isVideo(mediaSrc) ? "Body_2_semibold" : "Body_1_semibold",
-              isActive ? "text-Red-300" : "text-white group-hover:text-Red-300"
+              isActive ? "text-Red-300" : "text-white group-hover:text-Red-300",
             )}
           >
             {title}

--- a/src/components/dashboard/sidebar/CreatButton.tsx
+++ b/src/components/dashboard/sidebar/CreatButton.tsx
@@ -1,5 +1,8 @@
 import { Close, Pencil, Plus } from "@/assets/icons";
+import { PATHS } from "@/constants/common/paths";
+import { useRouter } from "@/i18n/routing";
 import { AnimatePresence, motion } from "framer-motion";
+import { useTranslations } from "next-intl";
 import GlassButton from "../../common/GlassButton";
 
 interface CreateButtonProps {
@@ -8,6 +11,9 @@ interface CreateButtonProps {
 }
 
 const CreateButton = ({ isCreateOpen, onClick }: CreateButtonProps) => {
+  const router = useRouter();
+  const t = useTranslations("dashboard");
+
   return (
     <div className="flex flex-col gap-[0.75rem] w-full">
       <AnimatePresence>
@@ -20,9 +26,12 @@ const CreateButton = ({ isCreateOpen, onClick }: CreateButtonProps) => {
               transition={{ duration: 0.25, ease: "easeOut" }}
               className="overflow-hidden Body_2_semibold text-grey-50"
             >
-              <GlassButton className="w-full bg-[rgba(255,48,48,0.45)] rounded-[0.25rem] hover:bg-[rgba(255,48,48,0.75)] Body_2_semibold flex gap-[0.62rem]">
-                <Plus className="w-[1.125rem]" />
-                <span>새 프로젝트 시작하기</span>
+              <GlassButton
+                onClick={() => router.push(PATHS.DASHBOARD_CREATE)}
+                className="w-full bg-[rgba(255,48,48,0.45)] rounded-[0.25rem] hover:bg-[rgba(255,48,48,0.75)] Body_2_semibold flex gap-[0.62rem]"
+              >
+                <Plus className="w-[1.5rem] h-[1.5rem] [&_path]:fill-White" />
+                <span>{t("sidebar.newProject")}</span>
               </GlassButton>
             </motion.div>
             <motion.div
@@ -32,9 +41,12 @@ const CreateButton = ({ isCreateOpen, onClick }: CreateButtonProps) => {
               transition={{ duration: 0.25, ease: "easeOut", delay: 0.05 }}
               className="overflow-hidden Body_2_semibold text-grey-50 flex gap-[1.125rem]"
             >
-              <GlassButton className="w-full">
+              <GlassButton
+                onClick={() => router.push(PATHS.DASHBOARD_CONTINUE)}
+                className="w-full"
+              >
                 <Pencil className="w-[1.125rem]" />
-                프로젝트 이어하기
+                {t("sidebar.continueProject")}
               </GlassButton>
             </motion.div>
           </>
@@ -106,8 +118,10 @@ const CreateButton = ({ isCreateOpen, onClick }: CreateButtonProps) => {
                 transition={{ duration: 0.15 }}
                 className="flex gap-[0.62rem] items-center"
               >
-                <Plus className="w-[1.125rem] h-[1.125rem]" color="white" />
-                <span className="Body_1_semibold">생성하기</span>
+                <Plus className="w-[1.5rem] h-[1.5rem] [&_path]:fill-White" />
+                <span className="Body_1_semibold">
+                  {t("sidebar.createButton")}
+                </span>
               </motion.div>
             )}
           </AnimatePresence>

--- a/src/components/dashboard/workbench/TabContent.tsx
+++ b/src/components/dashboard/workbench/TabContent.tsx
@@ -9,16 +9,20 @@ interface TabContentProps {
   uploadedImage: File | null;
   setUploadedImage: (file: File | null) => void;
   mode: WorkbenchMode;
+  cutoutImageObjectKey: string | null;
+  projectId: number | null;
+  onGenerated: (imageUrl: string) => void;
+  onGeneratingChange: (isGenerating: boolean) => void;
 }
 
-const TabContent = ({ activeTab, uploadedImage, setUploadedImage, mode }: TabContentProps) => {
+const TabContent = ({ activeTab, uploadedImage, setUploadedImage, mode, cutoutImageObjectKey, projectId, onGenerated, onGeneratingChange }: TabContentProps) => {
   switch (activeTab) {
     case 0:
       return <ProductTab setUploadedImage={setUploadedImage} />;
     case 1:
       return mode === "video"
         ? <OptionsTab uploadedImage={uploadedImage} />
-        : <BackgroundTab uploadedImage={uploadedImage} />;
+        : <BackgroundTab uploadedImage={uploadedImage} cutoutImageObjectKey={cutoutImageObjectKey} projectId={projectId} onGenerated={onGenerated} onGeneratingChange={onGeneratingChange} />;
     case 2:
       return <ChatbotTab />;
     default:

--- a/src/components/dashboard/workbench/Workbench.tsx
+++ b/src/components/dashboard/workbench/Workbench.tsx
@@ -11,15 +11,11 @@ import MarkCanvas from "@/components/dashboard/workbench/chatbot/MarkCanvas";
 import { useStudioMarkStore } from "@/stores/useStudioMarkStore";
 import ProductImageRequiredModal from "@/components/dashboard/workbench/background/ProductImageRequiredModal";
 import { useImageUploadAndCutout } from "@/hooks/useImageUploadAndCutout";
-import { useGetFolders } from "@/hooks/queries/useFolderApi";
+import {
+  useGetFolders,
+  useGetFolderDetail,
+} from "@/hooks/queries/useFolderApi";
 import type { WorkbenchMode } from "@/types/dashboard/mode.type";
-
-const DUMMY_HISTORY: HistoryItem[] = [
-  {
-    id: "dummy-1",
-    imageUrls: ["/images/dashboard/model.png", "/images/dashboard/studio.png"],
-  },
-];
 
 interface WorkbenchProps {
   mode: WorkbenchMode;
@@ -42,17 +38,34 @@ const Workbench = ({ mode }: WorkbenchProps) => {
   const [uploadedImage, setUploadedImage] = useState<File | null>(null);
   const [previewUrl, setPreviewUrl] = useState<string | null>(null);
 
-  const [history] = useState<HistoryItem[]>(DUMMY_HISTORY);
-  const [generatedImageUrl, setGeneratedImageUrl] = useState<string | null>(null);
+  const [generatedImageUrl, setGeneratedImageUrl] = useState<string | null>(
+    null,
+  );
   const [isGenerating, setIsGenerating] = useState(false);
 
   const { data: foldersData } = useGetFolders();
-  const folderId =
-    foldersData?.myProject[0]?.folderId ??
-    0;
+  const folderId = foldersData?.myProject[0]?.folderId ?? 0;
 
-  const { isProcessing, cutoutImageUrl, cutoutImageObjectKey, projectId, uploadAndCutout, resetCutout } =
-    useImageUploadAndCutout(folderId);
+  const { data: folderDetail } = useGetFolderDetail(folderId);
+  const images = folderDetail?.folders[0]?.images ?? [];
+
+  const history: HistoryItem[] = [];
+
+  for (let i = 0; i < images.length; i += 2) {
+    history.push({
+      id: String(i),
+      imageUrls: [images[i], images[i + 1] ?? images[i]],
+    });
+  }
+
+  const {
+    isProcessing,
+    cutoutImageUrl,
+    cutoutImageObjectKey,
+    projectId,
+    uploadAndCutout,
+    resetCutout,
+  } = useImageUploadAndCutout(folderId);
 
   const handleTabChange = (nextIdx: number) => {
     const isChatbotTab = nextIdx === 2;

--- a/src/components/dashboard/workbench/Workbench.tsx
+++ b/src/components/dashboard/workbench/Workbench.tsx
@@ -6,11 +6,12 @@ import { useTranslations } from "next-intl";
 
 import TabContent from "./TabContent";
 import TabPanel from "./TabPanel";
-import HistoryPanel, {
-  HistoryItem} from "./HistoryPanel";
+import HistoryPanel, { HistoryItem } from "./HistoryPanel";
 import MarkCanvas from "@/components/dashboard/workbench/chatbot/MarkCanvas";
 import { useStudioMarkStore } from "@/stores/useStudioMarkStore";
 import ProductImageRequiredModal from "@/components/dashboard/workbench/background/ProductImageRequiredModal";
+import { useImageUploadAndCutout } from "@/hooks/useImageUploadAndCutout";
+import { useGetFolders } from "@/hooks/queries/useFolderApi";
 import type { WorkbenchMode } from "@/types/dashboard/mode.type";
 
 const DUMMY_HISTORY: HistoryItem[] = [
@@ -43,6 +44,14 @@ const Workbench = ({ mode }: WorkbenchProps) => {
 
   const [history] = useState<HistoryItem[]>(DUMMY_HISTORY);
 
+  const { data: foldersData } = useGetFolders();
+  const folderId =
+    foldersData?.myProject[0]?.folderId ??
+    0;
+
+  const { isProcessing, cutoutImageUrl, uploadAndCutout, resetCutout } =
+    useImageUploadAndCutout(folderId);
+
   const handleTabChange = (nextIdx: number) => {
     const isChatbotTab = nextIdx === 2;
 
@@ -58,11 +67,13 @@ const Workbench = ({ mode }: WorkbenchProps) => {
     setNaturalSize(null);
     if (!uploadedImage) {
       setPreviewUrl(null);
+      resetCutout();
       return;
     }
 
     const url = URL.createObjectURL(uploadedImage);
     setPreviewUrl(url);
+    uploadAndCutout(uploadedImage);
 
     return () => {
       URL.revokeObjectURL(url);
@@ -72,7 +83,11 @@ const Workbench = ({ mode }: WorkbenchProps) => {
   return (
     <div className="flex justify-center w-full">
       <div className="flex flex-col">
-        <TabPanel activeTab={activeTab} onChange={handleTabChange} mode={mode} />
+        <TabPanel
+          activeTab={activeTab}
+          onChange={handleTabChange}
+          mode={mode}
+        />
         <TabContent
           activeTab={activeTab}
           uploadedImage={uploadedImage}
@@ -121,7 +136,7 @@ const Workbench = ({ mode }: WorkbenchProps) => {
               <Image
                 width={590}
                 height={646}
-                src={previewUrl}
+                src={cutoutImageUrl ?? previewUrl}
                 alt={t("uploadedImageAlt")}
                 className="w-full h-full object-contain"
                 onLoad={(e) => {
@@ -133,7 +148,13 @@ const Workbench = ({ mode }: WorkbenchProps) => {
                 }}
               />
 
-              {isEditMode && naturalSize && (
+              {isProcessing && (
+                <div className="absolute inset-0 flex items-center justify-center bg-Grey-900/60">
+                  <div className="w-10 h-10 border-4 border-Grey-600 border-t-White rounded-full animate-spin" />
+                </div>
+              )}
+
+              {isEditMode && naturalSize && !isProcessing && (
                 <MarkCanvas
                   imageContainerRef={imageContainerRef}
                   naturalSize={naturalSize}

--- a/src/components/dashboard/workbench/Workbench.tsx
+++ b/src/components/dashboard/workbench/Workbench.tsx
@@ -43,13 +43,15 @@ const Workbench = ({ mode }: WorkbenchProps) => {
   const [previewUrl, setPreviewUrl] = useState<string | null>(null);
 
   const [history] = useState<HistoryItem[]>(DUMMY_HISTORY);
+  const [generatedImageUrl, setGeneratedImageUrl] = useState<string | null>(null);
+  const [isGenerating, setIsGenerating] = useState(false);
 
   const { data: foldersData } = useGetFolders();
   const folderId =
     foldersData?.myProject[0]?.folderId ??
     0;
 
-  const { isProcessing, cutoutImageUrl, uploadAndCutout, resetCutout } =
+  const { isProcessing, cutoutImageUrl, cutoutImageObjectKey, projectId, uploadAndCutout, resetCutout } =
     useImageUploadAndCutout(folderId);
 
   const handleTabChange = (nextIdx: number) => {
@@ -65,6 +67,7 @@ const Workbench = ({ mode }: WorkbenchProps) => {
 
   useEffect(() => {
     setNaturalSize(null);
+    setGeneratedImageUrl(null);
     if (!uploadedImage) {
       setPreviewUrl(null);
       resetCutout();
@@ -93,6 +96,10 @@ const Workbench = ({ mode }: WorkbenchProps) => {
           uploadedImage={uploadedImage}
           setUploadedImage={setUploadedImage}
           mode={mode}
+          cutoutImageObjectKey={cutoutImageObjectKey}
+          projectId={projectId}
+          onGenerated={setGeneratedImageUrl}
+          onGeneratingChange={setIsGenerating}
         />
       </div>
 
@@ -136,7 +143,7 @@ const Workbench = ({ mode }: WorkbenchProps) => {
               <Image
                 width={590}
                 height={646}
-                src={cutoutImageUrl ?? previewUrl}
+                src={generatedImageUrl ?? cutoutImageUrl ?? previewUrl}
                 alt={t("uploadedImageAlt")}
                 className="w-full h-full object-contain"
                 onLoad={(e) => {
@@ -148,13 +155,13 @@ const Workbench = ({ mode }: WorkbenchProps) => {
                 }}
               />
 
-              {isProcessing && (
+              {(isProcessing || isGenerating) && (
                 <div className="absolute inset-0 flex items-center justify-center bg-Grey-900/60">
                   <div className="w-10 h-10 border-4 border-Grey-600 border-t-White rounded-full animate-spin" />
                 </div>
               )}
 
-              {isEditMode && naturalSize && !isProcessing && (
+              {isEditMode && naturalSize && !isProcessing && !isGenerating && (
                 <MarkCanvas
                   imageContainerRef={imageContainerRef}
                   naturalSize={naturalSize}

--- a/src/components/dashboard/workbench/background/BackgroundSwiper.tsx
+++ b/src/components/dashboard/workbench/background/BackgroundSwiper.tsx
@@ -47,14 +47,15 @@ const BackgroundSwiper = ({
         </h3>
       )}
 
-      <div className="relative items-center flex gap-3">
-        {!showSkeleton && (
-          <button className={`swiper-prev-${id}`} aria-label="이전">
-            <Down className="rotate-90 h-6 w-6" />
-          </button>
-        )}
+      <div className="relative items-center flex gap-3 justify-center">
+        <button
+          className={clsx(`swiper-prev-${id}`, showSkeleton && "invisible")}
+          aria-label="이전"
+        >
+          <Down className="rotate-90 h-6 w-6" />
+        </button>
 
-        <div className="flex-1 w-[324px] min-w-0">
+        <div className="w-[324px] min-w-0">
           {showSkeleton ? (
             <div className="flex gap-3 justify-center">
               {Array.from({ length: 3 }, (_, i) => (
@@ -87,7 +88,7 @@ const BackgroundSwiper = ({
                     <button
                       type="button"
                       onClick={() => onSelect(item.id)}
-                      className="w-full"
+                      className="w-[6.25rem]"
                     >
                       <div
                         className={clsx(
@@ -115,11 +116,12 @@ const BackgroundSwiper = ({
           )}
         </div>
 
-        {!showSkeleton && (
-          <button className={`swiper-next-${id}`} aria-label="다음">
-            <Down className="-rotate-90 h-6 w-6" />
-          </button>
-        )}
+        <button
+          className={clsx(`swiper-next-${id}`, showSkeleton && "invisible")}
+          aria-label="다음"
+        >
+          <Down className="-rotate-90 h-6 w-6" />
+        </button>
       </div>
     </section>
   );

--- a/src/components/dashboard/workbench/background/BackgroundTab.tsx
+++ b/src/components/dashboard/workbench/background/BackgroundTab.tsx
@@ -24,9 +24,10 @@ const BackgroundTab = ({ uploadedImage }: BackgroundTabProps) => {
   const t = useTranslations("dashboard.workbench.backgroundTab");
   const [isSearching, setIsSearching] = useState(false);
   const [searchKeyword, setSearchKeyword] = useState("");
-  const [selectedBackgroundId, setSelectedBackgroundId] = useState<
-    string | null
-  >(null);
+  const [selectedBackground, setSelectedBackground] = useState<{
+    sectionId: string;
+    itemId: string;
+  } | null>(null);
 
   const [isProductImageModalOpen, setIsProductImageModalOpen] = useState(false);
 
@@ -58,7 +59,7 @@ const BackgroundTab = ({ uploadedImage }: BackgroundTabProps) => {
       return;
     }
 
-    console.log("생성 시작", { uploadedImage, selectedBackgroundId });
+    console.log("생성 시작", { uploadedImage, selectedBackground });
   };
 
   return (
@@ -80,8 +81,8 @@ const BackgroundTab = ({ uploadedImage }: BackgroundTabProps) => {
             <BackgroundSwiper
               id="search"
               items={toItems(searchResults ?? [])}
-              selectedId={selectedBackgroundId}
-              onSelect={setSelectedBackgroundId}
+              selectedId={selectedBackground?.sectionId === "search" ? selectedBackground.itemId : null}
+              onSelect={(itemId) => setSelectedBackground({ sectionId: "search", itemId })}
               isLoading={isSearchLoading}
             />
           ) : (
@@ -96,8 +97,8 @@ const BackgroundTab = ({ uploadedImage }: BackgroundTabProps) => {
               id={keyword}
               title={getTitle(keyword)}
               items={findTemplates(keyword)}
-              selectedId={selectedBackgroundId}
-              onSelect={setSelectedBackgroundId}
+              selectedId={selectedBackground?.sectionId === keyword ? selectedBackground.itemId : null}
+              onSelect={(itemId) => setSelectedBackground({ sectionId: keyword, itemId })}
               isLoading={isLoading}
             />
           ))

--- a/src/components/dashboard/workbench/background/BackgroundTab.tsx
+++ b/src/components/dashboard/workbench/background/BackgroundTab.tsx
@@ -10,17 +10,22 @@ import SearchBar from "./SearchBar";
 import ProductImageRequiredModal from "./ProductImageRequiredModal";
 import GlassButton from "@/components/common/GlassButton";
 import { useTemplateKeywords, useTemplatesByKeyword, useSearchTemplates } from "@/hooks/queries/useTemplateApi";
+import { usePostImage } from "@/hooks/queries/useImageApi";
 import { TEMPLATE_KEYWORDS } from "@/constants/dashboard/template";
 import { TemplateKeyword } from "@/types/api/template.type";
 
 interface BackgroundTabProps {
   uploadedImage: File | null;
+  cutoutImageObjectKey: string | null;
+  projectId: number | null;
+  onGenerated: (imageUrl: string) => void;
+  onGeneratingChange: (isGenerating: boolean) => void;
 }
 
 const toItems = (templates: { templateId: number; imageObjectKey: string }[]) =>
   templates.map((t) => ({ id: String(t.templateId), src: t.imageObjectKey }));
 
-const BackgroundTab = ({ uploadedImage }: BackgroundTabProps) => {
+const BackgroundTab = ({ uploadedImage, cutoutImageObjectKey, projectId, onGenerated, onGeneratingChange }: BackgroundTabProps) => {
   const t = useTranslations("dashboard.workbench.backgroundTab");
   const [isSearching, setIsSearching] = useState(false);
   const [searchKeyword, setSearchKeyword] = useState("");
@@ -30,6 +35,8 @@ const BackgroundTab = ({ uploadedImage }: BackgroundTabProps) => {
   } | null>(null);
 
   const [isProductImageModalOpen, setIsProductImageModalOpen] = useState(false);
+
+  const { mutate: postImage, isPending: isGenerating } = usePostImage();
 
   const { data: keywords, isLoading: isKeywordsLoading } = useTemplateKeywords();
   const { data: templatesData, isLoading: isTemplatesLoading } = useTemplatesByKeyword({
@@ -58,8 +65,23 @@ const BackgroundTab = ({ uploadedImage }: BackgroundTabProps) => {
       setIsProductImageModalOpen(true);
       return;
     }
+    if (!cutoutImageObjectKey || !projectId || !selectedBackground) return;
 
-    console.log("생성 시작", { uploadedImage, selectedBackground });
+    onGeneratingChange(true);
+    postImage(
+      {
+        cutoutImageObjectKey,
+        templateId: Number(selectedBackground.itemId),
+        projectId,
+      },
+      {
+        onSuccess: (data) => {
+          onGenerated(data.imageUrl);
+          onGeneratingChange(false);
+        },
+        onError: () => onGeneratingChange(false),
+      },
+    );
   };
 
   return (
@@ -121,6 +143,7 @@ const BackgroundTab = ({ uploadedImage }: BackgroundTabProps) => {
           type="button"
           className="Body_2_semibold"
           onClick={handleClickGenerate}
+          disabled={isGenerating}
         >
           {t("generate")}
         </GlassButton>

--- a/src/components/login/GoogleLoginButton.tsx
+++ b/src/components/login/GoogleLoginButton.tsx
@@ -3,16 +3,20 @@
 import { Google } from "@/assets/icons";
 import { BASE_URL } from "@/apis/config";
 import { useLocale, useTranslations } from "next-intl";
+import { useSearchParams } from "next/navigation";
 
 const GoogleLoginButton = () => {
   const t = useTranslations("login");
   const locale = useLocale();
+  const searchParams = useSearchParams();
 
   const handleGoogleLogin = () => {
     if (!BASE_URL) {
       return;
     }
-    const redirectUrl = `${window.location.origin}/${locale}/dashboard`;
+    const callbackUrl = searchParams.get("callbackUrl");
+    const destination = callbackUrl ?? `/${locale}/dashboard`;
+    const redirectUrl = `${window.location.origin}${destination}`;
     window.location.href = `${BASE_URL}/api/v1/oauth/google?redirectUrl=${encodeURIComponent(redirectUrl)}`;
   };
 

--- a/src/components/login/GoogleLoginButton.tsx
+++ b/src/components/login/GoogleLoginButton.tsx
@@ -2,6 +2,7 @@
 
 import { Google } from "@/assets/icons";
 import { BASE_URL } from "@/apis/config";
+import { getSafeCallbackDestination } from "@/utils/authUtils";
 import { useLocale, useTranslations } from "next-intl";
 import { useSearchParams } from "next/navigation";
 
@@ -15,7 +16,7 @@ const GoogleLoginButton = () => {
       return;
     }
     const callbackUrl = searchParams.get("callbackUrl");
-    const destination = callbackUrl ?? `/${locale}/dashboard`;
+    const destination = getSafeCallbackDestination(callbackUrl, `/${locale}/dashboard`);
     const redirectUrl = `${window.location.origin}${destination}`;
     window.location.href = `${BASE_URL}/api/v1/oauth/google?redirectUrl=${encodeURIComponent(redirectUrl)}`;
   };

--- a/src/components/signup/EmailInputStep.tsx
+++ b/src/components/signup/EmailInputStep.tsx
@@ -110,7 +110,19 @@ const EmailInputStep = ({
         isOpen={!!errorType}
         onClose={() => setErrorType(null)}
         title={errorType ? t(`error.${errorType}.title`) : ""}
-        description={errorType ? t(`error.${errorType}.description`) : ""}
+        description={
+          errorType === "emailSendFailed"
+            ? [
+                t("error.emailSendFailed.description"),
+                <span key="contact" className="whitespace-pre-line">
+                  {t("error.emailSendFailed.contact")}{"\n"}
+                  <span className="text-Red-300">{t("error.emailSendFailed.contactEmail")}</span>
+                </span>,
+              ]
+            : errorType
+              ? t(`error.${errorType}.description`)
+              : ""
+        }
         buttons={[
           { label: t("error.confirm"), variant: "red", onClick: () => setErrorType(null) },
         ]}

--- a/src/hooks/queries/queryKeys.ts
+++ b/src/hooks/queries/queryKeys.ts
@@ -41,5 +41,6 @@ export const queryKeys = {
   folder: {
     all: ["folder"] as const,
     list: () => [...queryKeys.folder.all, "list"] as const,
+    detail: (folderId: number) => [...queryKeys.folder.all, "detail", folderId] as const,
   },
 } as const;

--- a/src/hooks/queries/queryKeys.ts
+++ b/src/hooks/queries/queryKeys.ts
@@ -30,4 +30,11 @@ export const queryKeys = {
     profileUploadUrl: () =>
       [...queryKeys.mypage.all, "profileUploadUrl"] as const,
   },
+
+  image: {
+    all: ["image"] as const,
+    detail: (imageId: number) =>
+      [...queryKeys.image.all, imageId] as const,
+    rawPresign: () => [...queryKeys.image.all, "rawPresign"] as const,
+  },
 } as const;

--- a/src/hooks/queries/queryKeys.ts
+++ b/src/hooks/queries/queryKeys.ts
@@ -33,14 +33,14 @@ export const queryKeys = {
 
   image: {
     all: ["image"] as const,
-    detail: (imageId: number) =>
-      [...queryKeys.image.all, imageId] as const,
+    detail: (imageId: number) => [...queryKeys.image.all, imageId] as const,
     rawPresign: () => [...queryKeys.image.all, "rawPresign"] as const,
   },
 
   folder: {
     all: ["folder"] as const,
     list: () => [...queryKeys.folder.all, "list"] as const,
-    detail: (folderId: number) => [...queryKeys.folder.all, "detail", folderId] as const,
+    detail: (folderId: number, pageNum?: number, limit?: number) =>
+      [...queryKeys.folder.all, "detail", folderId, pageNum, limit] as const,
   },
 } as const;

--- a/src/hooks/queries/queryKeys.ts
+++ b/src/hooks/queries/queryKeys.ts
@@ -37,4 +37,9 @@ export const queryKeys = {
       [...queryKeys.image.all, imageId] as const,
     rawPresign: () => [...queryKeys.image.all, "rawPresign"] as const,
   },
+
+  folder: {
+    all: ["folder"] as const,
+    list: () => [...queryKeys.folder.all, "list"] as const,
+  },
 } as const;

--- a/src/hooks/queries/useFolderApi.ts
+++ b/src/hooks/queries/useFolderApi.ts
@@ -11,7 +11,7 @@ export const useGetFolders = () =>
 
 export const useGetFolderDetail = (folderId: number, pageNum = 1, limit = 10) =>
   useQuery({
-    queryKey: queryKeys.folder.detail(folderId),
+    queryKey: queryKeys.folder.detail(folderId, pageNum, limit),
     queryFn: () => getFolderDetail({ folderId, pageNum, limit }),
     enabled: !!folderId,
   });

--- a/src/hooks/queries/useFolderApi.ts
+++ b/src/hooks/queries/useFolderApi.ts
@@ -1,0 +1,10 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { getFolders } from "@/apis/folderApi";
+import { queryKeys } from "./queryKeys";
+
+export const useGetFolders = () =>
+  useQuery({
+    queryKey: queryKeys.folder.list(),
+    queryFn: getFolders,
+  });

--- a/src/hooks/queries/useFolderApi.ts
+++ b/src/hooks/queries/useFolderApi.ts
@@ -1,10 +1,17 @@
 import { useQuery } from "@tanstack/react-query";
 
-import { getFolders } from "@/apis/folderApi";
+import { getFolders, getFolderDetail } from "@/apis/folderApi";
 import { queryKeys } from "./queryKeys";
 
 export const useGetFolders = () =>
   useQuery({
     queryKey: queryKeys.folder.list(),
     queryFn: getFolders,
+  });
+
+export const useGetFolderDetail = (folderId: number, pageNum = 1, limit = 10) =>
+  useQuery({
+    queryKey: queryKeys.folder.detail(folderId),
+    queryFn: () => getFolderDetail({ folderId, pageNum, limit }),
+    enabled: !!folderId,
   });

--- a/src/hooks/queries/useImageApi.ts
+++ b/src/hooks/queries/useImageApi.ts
@@ -1,19 +1,8 @@
 import { useMutation, useQuery } from "@tanstack/react-query";
 
-import {
-  getRawPresign,
-  postCutoutImage,
-  postImage,
-  getImage,
-} from "@/apis/imageApi";
+import { postCutoutImage, postImage, getImage } from "@/apis/imageApi";
 
 import { queryKeys } from "./queryKeys";
-
-export const useRawPresign = () =>
-  useQuery({
-    queryKey: queryKeys.image.rawPresign(),
-    queryFn: getRawPresign,
-  });
 
 export const useGetImage = (imageId: number) =>
   useQuery({

--- a/src/hooks/queries/useImageApi.ts
+++ b/src/hooks/queries/useImageApi.ts
@@ -1,0 +1,33 @@
+import { useMutation, useQuery } from "@tanstack/react-query";
+
+import {
+  getRawPresign,
+  postCutoutImage,
+  postImage,
+  getImage,
+} from "@/apis/imageApi";
+
+import { queryKeys } from "./queryKeys";
+
+export const useRawPresign = () =>
+  useQuery({
+    queryKey: queryKeys.image.rawPresign(),
+    queryFn: getRawPresign,
+  });
+
+export const useGetImage = (imageId: number) =>
+  useQuery({
+    queryKey: queryKeys.image.detail(imageId),
+    queryFn: () => getImage(imageId),
+    enabled: !!imageId,
+  });
+
+export const usePostCutoutImage = () =>
+  useMutation({
+    mutationFn: postCutoutImage,
+  });
+
+export const usePostImage = () =>
+  useMutation({
+    mutationFn: postImage,
+  });

--- a/src/hooks/queries/useMypageApi.ts
+++ b/src/hooks/queries/useMypageApi.ts
@@ -1,11 +1,6 @@
 import { useMutation, useQuery } from "@tanstack/react-query";
 
-import {
-  getMypage,
-  updateUsername,
-  getProfileUploadUrl,
-  updateProfileImage,
-} from "@/apis/mypageApi";
+import { getMypage, updateUsername } from "@/apis/mypageApi";
 
 import { queryKeys } from "./queryKeys";
 
@@ -19,9 +14,4 @@ export const useMypage = () =>
 export const useUpdateUsername = () =>
   useMutation({
     mutationFn: updateUsername,
-  });
-
-export const useUpdateProfileImage = () =>
-  useMutation({
-    mutationFn: updateProfileImage,
   });

--- a/src/hooks/useActivePage.ts
+++ b/src/hooks/useActivePage.ts
@@ -7,7 +7,8 @@ export function useActivePage<T extends Record<string, string>>(
   const pathname = usePathname();
 
   return useMemo(() => {
-    const entry = Object.entries(config).find(([_, path]) => pathname === path);
+    const strippedPathname = "/" + pathname.split("/").slice(2).join("/");
+    const entry = Object.entries(config).find(([_, path]) => strippedPathname === path);
     return entry?.[0] as keyof T | undefined;
   }, [pathname, config]);
 }

--- a/src/hooks/useImageUploadAndCutout.ts
+++ b/src/hooks/useImageUploadAndCutout.ts
@@ -11,7 +11,7 @@ export const useImageUploadAndCutout = (folderId: number) => {
     setCutoutImageUrl(null);
 
     try {
-      const { uploadUrl, rawImageObjectKey } = await getRawPresign();
+      const { uploadUrl, objectKey } = await getRawPresign();
       const uploadResponse = await fetch(uploadUrl, {
         method: "PUT",
         body: file,
@@ -23,7 +23,7 @@ export const useImageUploadAndCutout = (folderId: number) => {
       }
 
       const { cutoutImageUrl: resultUrl } = await postCutoutImage({
-        rawObjectKey: rawImageObjectKey,
+        rawObjectKey: objectKey,
         folderId,
       });
 

--- a/src/hooks/useImageUploadAndCutout.ts
+++ b/src/hooks/useImageUploadAndCutout.ts
@@ -1,51 +1,67 @@
-import { useState } from "react";
+import { useCallback, useState } from "react";
 
 import { getRawPresign, postCutoutImage } from "@/apis/imageApi";
 
 export const useImageUploadAndCutout = (folderId: number) => {
-  const [isProcessing, setIsProcessing] = useState(true);
+  const [isProcessing, setIsProcessing] = useState(false);
   const [cutoutImageUrl, setCutoutImageUrl] = useState<string | null>(null);
-  const [cutoutImageObjectKey, setCutoutImageObjectKey] = useState<string | null>(null);
+  const [cutoutImageObjectKey, setCutoutImageObjectKey] = useState<
+    string | null
+  >(null);
   const [projectId, setProjectId] = useState<number | null>(null);
 
-  const uploadAndCutout = async (file: File) => {
-    setIsProcessing(true);
-    setCutoutImageUrl(null);
-    setCutoutImageObjectKey(null);
-    setProjectId(null);
+  const uploadAndCutout = useCallback(
+    async (file: File) => {
+      setIsProcessing(true);
+      setCutoutImageUrl(null);
+      setCutoutImageObjectKey(null);
+      setProjectId(null);
 
-    try {
-      const { uploadUrl, objectKey } = await getRawPresign();
-      const uploadResponse = await fetch(uploadUrl, {
-        method: "PUT",
-        body: file,
-        headers: { "Content-Type": file.type },
-      });
+      try {
+        const { uploadUrl, objectKey } = await getRawPresign();
+        const uploadResponse = await fetch(uploadUrl, {
+          method: "PUT",
+          body: file,
+          headers: { "Content-Type": file.type },
+        });
 
-      if (!uploadResponse.ok) {
-        throw new Error("파일 업로드 실패");
+        if (!uploadResponse.ok) {
+          throw new Error("파일 업로드 실패");
+        }
+
+        const {
+          cutoutImageUrl: resultUrl,
+          cutoutImageObjectKey: resultObjectKey,
+          projectId: resultProjectId,
+        } = await postCutoutImage({
+          rawObjectKey: objectKey,
+          folderId,
+        });
+
+        setCutoutImageUrl(resultUrl);
+        setCutoutImageObjectKey(resultObjectKey);
+        setProjectId(resultProjectId);
+      } catch (error) {
+        console.error("누끼 처리 실패:", error);
+      } finally {
+        setIsProcessing(false);
       }
+    },
+    [folderId],
+  );
 
-      const { cutoutImageUrl: resultUrl, cutoutImageObjectKey: resultObjectKey, projectId: resultProjectId } = await postCutoutImage({
-        rawObjectKey: objectKey,
-        folderId,
-      });
-
-      setCutoutImageUrl(resultUrl);
-      setCutoutImageObjectKey(resultObjectKey);
-      setProjectId(resultProjectId);
-    } catch (error) {
-      console.error("누끼 처리 실패:", error);
-    } finally {
-      setIsProcessing(false);
-    }
-  };
-
-  const resetCutout = () => {
+  const resetCutout = useCallback(() => {
     setCutoutImageUrl(null);
     setCutoutImageObjectKey(null);
     setProjectId(null);
-  };
+  }, []);
 
-  return { isProcessing, cutoutImageUrl, cutoutImageObjectKey, projectId, uploadAndCutout, resetCutout };
+  return {
+    isProcessing,
+    cutoutImageUrl,
+    cutoutImageObjectKey,
+    projectId,
+    uploadAndCutout,
+    resetCutout,
+  };
 };

--- a/src/hooks/useImageUploadAndCutout.ts
+++ b/src/hooks/useImageUploadAndCutout.ts
@@ -1,0 +1,43 @@
+import { useState } from "react";
+
+import { getRawPresign, postCutoutImage } from "@/apis/imageApi";
+
+export const useImageUploadAndCutout = (folderId: number) => {
+  const [isProcessing, setIsProcessing] = useState(true);
+  const [cutoutImageUrl, setCutoutImageUrl] = useState<string | null>(null);
+
+  const uploadAndCutout = async (file: File) => {
+    setIsProcessing(true);
+    setCutoutImageUrl(null);
+
+    try {
+      const { uploadUrl, rawImageObjectKey } = await getRawPresign();
+      const uploadResponse = await fetch(uploadUrl, {
+        method: "PUT",
+        body: file,
+        headers: { "Content-Type": file.type },
+      });
+
+      if (!uploadResponse.ok) {
+        throw new Error("파일 업로드 실패");
+      }
+
+      const { cutoutImageUrl: resultUrl } = await postCutoutImage({
+        rawObjectKey: rawImageObjectKey,
+        folderId,
+      });
+
+      setCutoutImageUrl(resultUrl);
+    } catch (error) {
+      console.error("누끼 처리 실패:", error);
+    } finally {
+      setIsProcessing(false);
+    }
+  };
+
+  const resetCutout = () => {
+    setCutoutImageUrl(null);
+  };
+
+  return { isProcessing, cutoutImageUrl, uploadAndCutout, resetCutout };
+};

--- a/src/hooks/useImageUploadAndCutout.ts
+++ b/src/hooks/useImageUploadAndCutout.ts
@@ -5,10 +5,14 @@ import { getRawPresign, postCutoutImage } from "@/apis/imageApi";
 export const useImageUploadAndCutout = (folderId: number) => {
   const [isProcessing, setIsProcessing] = useState(true);
   const [cutoutImageUrl, setCutoutImageUrl] = useState<string | null>(null);
+  const [cutoutImageObjectKey, setCutoutImageObjectKey] = useState<string | null>(null);
+  const [projectId, setProjectId] = useState<number | null>(null);
 
   const uploadAndCutout = async (file: File) => {
     setIsProcessing(true);
     setCutoutImageUrl(null);
+    setCutoutImageObjectKey(null);
+    setProjectId(null);
 
     try {
       const { uploadUrl, objectKey } = await getRawPresign();
@@ -22,12 +26,14 @@ export const useImageUploadAndCutout = (folderId: number) => {
         throw new Error("파일 업로드 실패");
       }
 
-      const { cutoutImageUrl: resultUrl } = await postCutoutImage({
+      const { cutoutImageUrl: resultUrl, cutoutImageObjectKey: resultObjectKey, projectId: resultProjectId } = await postCutoutImage({
         rawObjectKey: objectKey,
         folderId,
       });
 
       setCutoutImageUrl(resultUrl);
+      setCutoutImageObjectKey(resultObjectKey);
+      setProjectId(resultProjectId);
     } catch (error) {
       console.error("누끼 처리 실패:", error);
     } finally {
@@ -37,7 +43,9 @@ export const useImageUploadAndCutout = (folderId: number) => {
 
   const resetCutout = () => {
     setCutoutImageUrl(null);
+    setCutoutImageObjectKey(null);
+    setProjectId(null);
   };
 
-  return { isProcessing, cutoutImageUrl, uploadAndCutout, resetCutout };
+  return { isProcessing, cutoutImageUrl, cutoutImageObjectKey, projectId, uploadAndCutout, resetCutout };
 };

--- a/src/types/api/folder.type.ts
+++ b/src/types/api/folder.type.ts
@@ -1,0 +1,9 @@
+export interface FolderItem {
+  folderId: number;
+  name: string;
+}
+
+export interface GetFoldersResponse {
+  myProject: FolderItem[];
+  sharedProject: FolderItem[];
+}

--- a/src/types/api/folder.type.ts
+++ b/src/types/api/folder.type.ts
@@ -1,3 +1,5 @@
+import { PageInfo } from "./common.type";
+
 export interface FolderItem {
   folderId: number;
   name: string;
@@ -6,4 +8,22 @@ export interface FolderItem {
 export interface GetFoldersResponse {
   myProject: FolderItem[];
   sharedProject: FolderItem[];
+}
+
+export interface FolderDetailItem {
+  folderId: number;
+  folderName: string;
+  images: string[];
+}
+
+export interface GetFolderDetailResponse {
+  folders: FolderDetailItem[];
+  pageInfo: PageInfo;
+}
+
+export interface GetFolderDetailParams {
+  folderId: number;
+  pageNum: number;
+  limit: number;
+  sort?: "ASC" | "DESC";
 }

--- a/src/types/api/image.type.ts
+++ b/src/types/api/image.type.ts
@@ -36,6 +36,6 @@ export interface GetImageResponse {
 // 원본 이미지 presigned URL 조회 응답
 export interface GetRawPresignResponse {
   uploadUrl: string;
-  rawImageObjectKey: string;
-  rawImageUrl: string;
+  objectKey: string;
+  imageUrl: string;
 }

--- a/src/types/api/image.type.ts
+++ b/src/types/api/image.type.ts
@@ -1,0 +1,39 @@
+// POST /api/v1/image/cutout
+export interface PostCutoutImageRequest {
+  rawObjectKey: string;
+  folderId: number;
+}
+
+export interface PostCutoutImageResponse {
+  projectId: number;
+  cutoutImageObjectKey: string;
+  cutoutImageUrl: string;
+}
+
+// POST /api/v1/image
+export interface PostImageRequest {
+  cutoutImageObjectKey: string;
+  templateId: number;
+  projectId: number;
+}
+
+export interface PostImageResponse {
+  imageId: number;
+  imageUrl: string;
+}
+
+// GET /api/v1/image/{imageId}
+export interface GetImageResponse {
+  imageId: number;
+  imageUrl: string;
+  projectId: number;
+  templateId: number;
+  folderId: number;
+}
+
+// GET /api/v1/image/raw/presign
+export interface GetRawPresignResponse {
+  uploadUrl: string;
+  rawImageObjectKey: string;
+  rawImageUrl: string;
+}

--- a/src/types/api/image.type.ts
+++ b/src/types/api/image.type.ts
@@ -1,28 +1,30 @@
-// POST /api/v1/image/cutout
+// 누끼 이미지 생성 요청
 export interface PostCutoutImageRequest {
   rawObjectKey: string;
   folderId: number;
 }
 
+// 누끼 이미지 생성 응답
 export interface PostCutoutImageResponse {
   projectId: number;
   cutoutImageObjectKey: string;
   cutoutImageUrl: string;
 }
 
-// POST /api/v1/image
+// 합성 이미지 생성 요청
 export interface PostImageRequest {
   cutoutImageObjectKey: string;
   templateId: number;
   projectId: number;
 }
 
+// 합성 이미지 생성 응답
 export interface PostImageResponse {
   imageId: number;
   imageUrl: string;
 }
 
-// GET /api/v1/image/{imageId}
+// 이미지 상세 조회 응답
 export interface GetImageResponse {
   imageId: number;
   imageUrl: string;
@@ -31,7 +33,7 @@ export interface GetImageResponse {
   folderId: number;
 }
 
-// GET /api/v1/image/raw/presign
+// 원본 이미지 presigned URL 조회 응답
 export interface GetRawPresignResponse {
   uploadUrl: string;
   rawImageObjectKey: string;

--- a/src/utils/authUtils.ts
+++ b/src/utils/authUtils.ts
@@ -1,0 +1,12 @@
+export function getSafeCallbackDestination(
+  callbackUrl: string | null,
+  fallback: string,
+): string {
+  const isValid =
+    callbackUrl !== null &&
+    callbackUrl.startsWith("/") &&
+    !callbackUrl.startsWith("//") &&
+    !callbackUrl.includes(":");
+
+  return isValid ? callbackUrl : fallback;
+}


### PR DESCRIPTION
## 💡 PR 타입

- [x] 기능 추가
- [x] 버그 수정
- [x] 코드 개선
- [ ] 문서 수정
- [ ] 기타

## 📝 PR 내용

**1. 이미지 도메인 API 및 타입을 추가했습니다.**
- 원본 이미지 업로드를 위한 presigned URL 조회 API를 추가했습니다.
- 누끼 이미지 생성 API를 연동했습니다.
- 배경 템플릿 기반 이미지 합성 API를 연동했습니다.
- 이미지 상세 조회 API를 추가했습니다.

**2. 폴더 도메인 API 및 타입을 추가했습니다.**  
(이미지 합성 플로우에서 필요하여 추가했습니다. 충돌 발생 시 정리하도록 하겠습니다.)
- 폴더 목록 조회 API를 추가했습니다.
- 폴더 상세 조회 API를 추가했습니다.

**3. 워크벤치 이미지 생성 플로우를 구현했습니다.**
- 업로드한 이미지를 S3에 업로드한 후 누끼 생성까지 이어지는 로직을 구현했습니다.
- 생성된 `cutoutImageObjectKey`와 `projectId`를 기반으로 배경 합성 API를 연동했습니다.
- 합성 결과 이미지를 메인 미리보기 영역에 반영하도록 구현했습니다.
- 이미지 생성 및 처리 중 로딩 오버레이가 표시되도록 처리했습니다.

**4. 히스토리 영역을 API 기반으로 연동했습니다.**
- 폴더 상세 조회 결과의 `images` 배열을 2개씩 묶어 `HistoryPanel`에 표시하도록 구현했습니다.

**5. 로그인 및 리다이렉트 로직을 개선했습니다.**
- 403 에러 발생 시 `login / signup / password-reset` 페이지를 제외하고 로그인 페이지로 이동하도록 수정했습니다.
- 로그인 성공 후 `callbackUrl`을 기준으로 이전 페이지로 복귀하도록 수정했습니다.

**6. 대시보드 및 사이드바 UI를 개선했습니다.**
- `DashboardCard` 클릭 시 workbench 페이지로 이동하도록 라우팅을 연결했습니다.
- 사이드바 생성 버튼 문구를 다국어 처리했습니다.
- 새 프로젝트 시작 / 프로젝트 이어하기 버튼에 라우팅을 연결했습니다.

**7. 공통 UI를 보완했습니다.**
- `AlertModal`이 배열 형태의 description도 받을 수 있도록 확장했습니다.
- 이메일 전송 실패 모달에 문의 문구 및 이메일을 표시하도록 수정했습니다.
- Continue 페이지의 여백을 수정했습니다.
- MobileModal 이미지에 `unoptimized` 옵션을 적용했습니다.

## 🔍 관련 이슈

- closes #57

## ✅ 체크리스트

- [ ] 테스트 코드를 작성하였는가?
- [ ] 관련 문서를 업데이트하였는가?
- [x] 발생 가능한 에러를 처리하였는가?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 대시보드 사이드바에 프로젝트 생성/계속하기 버튼 추가
  * 폴더 기반 이미지 히스토리 및 이미지 업로드→누끼 처리→생성 워크플로우 추가
  * 이미지 생성(퍼스트/후처리) 흐름과 진행 상태 표시 추가

* **버그 수정**
  * 403 처리 시 로그인 후 원래 페이지로 복귀되는 리다이렉트 동작 개선

* **개선 사항**
  * 회원가입 이메일 실패 메시지에 연락처 및 이메일 안내 추가
  * 알림 모달에서 다중 설명(여러 문단) 지원
  * 일부 대시보드 여백 및 카드 상호작용(키보드 접근성) 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->