### PR TITLE
[Feat] 비밀번호 재설정 API 연동

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -90,6 +90,7 @@
       "codePlaceholder": "6-digit code",
       "codeAriaLabel": "Verification code",
       "submit": "Continue",
+      "invalidCode": "*Invalid verification code.",
       "noEmail": "Didn't receive the email?",
       "timerMinutes": "You can resend in {minutes}:{seconds}.",
       "timerSeconds": "You can resend in {seconds}s.",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -90,6 +90,7 @@
       "codePlaceholder": "인증코드 6자리",
       "codeAriaLabel": "인증코드",
       "submit": "계속하기",
+      "invalidCode": "*유효하지 않은 인증 코드입니다.",
       "noEmail": "아직 이메일을 받지 못했나요?",
       "timerMinutes": "{minutes}:{seconds} 뒤에 재전송할 수 있습니다.",
       "timerSeconds": "{seconds}초 뒤에 재전송할 수 있습니다.",

--- a/src/apis/authApi.ts
+++ b/src/apis/authApi.ts
@@ -6,6 +6,9 @@ import {
   LoginResponse,
   SendVerificationEmailRequest,
   EmailValidationResponse,
+  PasswordEmailVerificationRequest,
+  PasswordCodeVerificationRequest,
+  PasswordResetRequest,
 } from "@/types/api/auth.type";
 
 // 토큰 갱신
@@ -45,4 +48,25 @@ export const checkEmailValidation = async (
     { params: { email } },
   );
   return response.data;
+};
+
+// 비밀번호 재설정 이메일 인증 요청
+export const sendPasswordEmailVerification = async (
+  body: PasswordEmailVerificationRequest,
+): Promise<void> => {
+  await axiosInstance.post("/auth/password/email/verification", body);
+};
+
+// 비밀번호 재설정 코드 인증
+export const verifyPasswordCode = async (
+  body: PasswordCodeVerificationRequest,
+): Promise<void> => {
+  await axiosInstance.post("/auth/password/code/verification", body);
+};
+
+// 비밀번호 변경
+export const resetPassword = async (
+  body: PasswordResetRequest,
+): Promise<void> => {
+  await axiosInstance.put("/auth/password", body);
 };

--- a/src/app/[locale]/password-reset/page.tsx
+++ b/src/app/[locale]/password-reset/page.tsx
@@ -13,6 +13,11 @@ import {
   PASSWORD_RESET_FUNNEL_ID,
   PASSWORD_RESET_STEPS,
 } from "@/constants/passwordReset/funnel";
+import {
+  useSendPasswordEmailVerification,
+  useVerifyPasswordCode,
+  useResetPassword,
+} from "@/hooks/queries/useAuthApi";
 
 import EmailInputStep from "@/components/passwordReset/EmailInputStep";
 import CodeVerificationStep from "@/components/passwordReset/CodeVerificationStep";
@@ -24,6 +29,10 @@ const PasswordResetPage = () => {
   const router = useRouter();
   const t = useTranslations("passwordReset");
   const [isCompleteModalOpen, setIsCompleteModalOpen] = useState(false);
+
+  const sendPasswordEmailVerification = useSendPasswordEmailVerification();
+  const verifyPasswordCode = useVerifyPasswordCode();
+  const resetPassword = useResetPassword();
 
   const funnel = useFunnel<PasswordResetFunnelSteps>({
     id: PASSWORD_RESET_FUNNEL_ID,
@@ -56,9 +65,12 @@ const PasswordResetPage = () => {
               EmailInput={({ context, history }) => (
                 <EmailInputStep
                   email={context.email ?? ""}
-                  onNext={({ email }) => {
+                  isLoading={sendPasswordEmailVerification.isPending}
+                  onNext={async ({ email }) => {
+                    await sendPasswordEmailVerification.mutateAsync({ email });
                     history.push(PASSWORD_RESET_STEPS.CODE_VERIFICATION, {
                       email,
+                      sentAt: Date.now(),
                     });
                   }}
                 />
@@ -66,20 +78,35 @@ const PasswordResetPage = () => {
               CodeVerification={({ context, history }) => (
                 <CodeVerificationStep
                   email={context.email}
-                  onNext={({ code }) => {
+                  sentAt={context.sentAt}
+                  isLoading={verifyPasswordCode.isPending}
+                  isResending={sendPasswordEmailVerification.isPending}
+                  isError={verifyPasswordCode.isError}
+                  onNext={async ({ code }) => {
+                    await verifyPasswordCode.mutateAsync({
+                      email: context.email,
+                      code,
+                    });
                     history.push(PASSWORD_RESET_STEPS.PASSWORD_RESET, {
                       ...context,
                       code,
                     });
                   }}
-                  onResend={() => {
-                    // TODO: 인증코드 재전송 API 호출
+                  onResend={async () => {
+                    await sendPasswordEmailVerification.mutateAsync({
+                      email: context.email,
+                    });
                   }}
                 />
               )}
               PasswordReset={({ context }) => (
                 <PasswordResetStep
-                  onComplete={() => {
+                  isLoading={resetPassword.isPending}
+                  onComplete={async ({ password }) => {
+                    await resetPassword.mutateAsync({
+                      email: context.email,
+                      password,
+                    });
                     setIsCompleteModalOpen(true);
                   }}
                 />

--- a/src/components/passwordReset/CodeVerificationStep.tsx
+++ b/src/components/passwordReset/CodeVerificationStep.tsx
@@ -11,12 +11,18 @@ const TIMER_SECONDS = 300;
 
 const CodeVerificationStep = ({
   email,
+  sentAt,
+  isLoading,
+  isResending,
+  isError,
   onNext,
   onResend,
 }: CodeVerificationStepProps) => {
   const t = useTranslations("passwordReset.codeVerification");
   const [code, setCode] = useState("");
-  const [remainingSeconds, setRemainingSeconds] = useState(TIMER_SECONDS);
+  const [remainingSeconds, setRemainingSeconds] = useState(() =>
+    Math.max(0, TIMER_SECONDS - Math.floor((Date.now() - sentAt) / 1000)),
+  );
 
   const isExpired = remainingSeconds <= 0;
   const isValidCode = /^\d{6}$/.test(code);
@@ -65,6 +71,12 @@ const CodeVerificationStep = ({
           ariaLabel={t("codeAriaLabel")}
         />
 
+        {isError && (
+          <span className="Body_3_regular text-Red-350 mt-2 block">
+            {t("invalidCode")}
+          </span>
+        )}
+
         <div className="mt-9 text-left flex">
           {!isExpired && (
             <>
@@ -84,6 +96,7 @@ const CodeVerificationStep = ({
             variant="red"
             size="xl"
             className="Body_2_semibold mt-3 w-full"
+            disabled={isResending}
             onClick={handleResend}
           >
             {t("resend")}
@@ -94,7 +107,7 @@ const CodeVerificationStep = ({
             variant="red"
             size="xl"
             className="Body_2_semibold mt-3 w-full"
-            disabled={!isValidCode}
+            disabled={!isValidCode || isLoading}
           >
             {t("submit")}
           </GlassButton>

--- a/src/components/passwordReset/CodeVerificationStep.tsx
+++ b/src/components/passwordReset/CodeVerificationStep.tsx
@@ -28,6 +28,12 @@ const CodeVerificationStep = ({
   const isValidCode = /^\d{6}$/.test(code);
 
   useEffect(() => {
+    setRemainingSeconds(
+      Math.max(0, TIMER_SECONDS - Math.floor((Date.now() - sentAt) / 1000)),
+    );
+  }, [sentAt]);
+
+  useEffect(() => {
     if (isExpired) return;
 
     const interval = setInterval(() => {
@@ -51,10 +57,10 @@ const CodeVerificationStep = ({
     onNext({ code });
   };
 
-  const handleResend = useCallback(() => {
+  const handleResend = useCallback(async () => {
+    await onResend();
     setCode("");
     setRemainingSeconds(TIMER_SECONDS);
-    onResend();
   }, [onResend]);
 
   return (

--- a/src/components/passwordReset/EmailInputStep.tsx
+++ b/src/components/passwordReset/EmailInputStep.tsx
@@ -7,7 +7,7 @@ import LoginInput from "@/components/login/LoginInput";
 import { EMAIL_REGEX } from "@/constants/signup/funnel";
 import type { EmailInputStepProps } from "@/types/passwordReset/funnel.type";
 
-const EmailInputStep = ({ email: initialEmail, onNext }: EmailInputStepProps) => {
+const EmailInputStep = ({ email: initialEmail, isLoading, onNext }: EmailInputStepProps) => {
   const t = useTranslations("passwordReset.emailInput");
   const [email, setEmail] = useState(initialEmail);
 
@@ -15,7 +15,7 @@ const EmailInputStep = ({ email: initialEmail, onNext }: EmailInputStepProps) =>
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    if (!isValidEmail) return;
+    if (!isValidEmail || isLoading) return;
     onNext({ email: email.trim() });
   };
 
@@ -38,7 +38,7 @@ const EmailInputStep = ({ email: initialEmail, onNext }: EmailInputStepProps) =>
           variant="red"
           size="xl"
           className="Body_2_semibold w-full"
-          disabled={!isValidEmail}
+          disabled={!isValidEmail || isLoading}
         >
           {t("submit")}
         </GlassButton>

--- a/src/components/passwordReset/PasswordResetStep.tsx
+++ b/src/components/passwordReset/PasswordResetStep.tsx
@@ -7,7 +7,7 @@ import LoginInput from "@/components/login/LoginInput";
 import { PASSWORD_REGEX } from "@/constants/signup/funnel";
 import type { PasswordResetStepProps } from "@/types/passwordReset/funnel.type";
 
-const PasswordResetStep = ({ onComplete }: PasswordResetStepProps) => {
+const PasswordResetStep = ({ isLoading, onComplete }: PasswordResetStepProps) => {
   const t = useTranslations("passwordReset.passwordSetup");
   const [password, setPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
@@ -71,7 +71,7 @@ const PasswordResetStep = ({ onComplete }: PasswordResetStepProps) => {
           variant="red"
           size="xl"
           className="Body_2_semibold mt-8 w-full"
-          disabled={isSubmitDisabled}
+          disabled={isSubmitDisabled || isLoading}
         >
           {t("submit")}
         </GlassButton>

--- a/src/hooks/queries/useAuthApi.ts
+++ b/src/hooks/queries/useAuthApi.ts
@@ -1,6 +1,6 @@
 import { useMutation } from "@tanstack/react-query";
 
-import { signup, login, sendVerificationEmail, checkEmailValidation } from "@/apis/authApi";
+import { signup, login, sendVerificationEmail, checkEmailValidation, sendPasswordEmailVerification, verifyPasswordCode, resetPassword } from "@/apis/authApi";
 
 export const useSignup = () =>
   useMutation({
@@ -20,4 +20,19 @@ export const useSendVerificationEmail = () =>
 export const useCheckEmailValidation = () =>
   useMutation({
     mutationFn: checkEmailValidation,
+  });
+
+export const useSendPasswordEmailVerification = () =>
+  useMutation({
+    mutationFn: sendPasswordEmailVerification,
+  });
+
+export const useVerifyPasswordCode = () =>
+  useMutation({
+    mutationFn: verifyPasswordCode,
+  });
+
+export const useResetPassword = () =>
+  useMutation({
+    mutationFn: resetPassword,
   });

--- a/src/types/api/auth.type.ts
+++ b/src/types/api/auth.type.ts
@@ -37,3 +37,20 @@ export interface SendVerificationEmailRequest {
   email: string;
   callbackUrl: string;
 }
+
+// 비밀번호 재설정 이메일 인증 요청
+export interface PasswordEmailVerificationRequest {
+  email: string;
+}
+
+// 비밀번호 재설정 코드 인증 요청
+export interface PasswordCodeVerificationRequest {
+  email: string;
+  code: string;
+}
+
+// 비밀번호 변경 요청
+export interface PasswordResetRequest {
+  email: string;
+  password: string;
+}

--- a/src/types/passwordReset/funnel.type.ts
+++ b/src/types/passwordReset/funnel.type.ts
@@ -4,10 +4,12 @@ export type EmailInputContext = {
 
 export type CodeVerificationContext = {
   email: string;
+  sentAt: number;
 };
 
 export type PasswordResetContext = {
   email: string;
+  sentAt: number;
   code: string;
 };
 
@@ -19,15 +21,21 @@ export type PasswordResetFunnelSteps = {
 
 export interface EmailInputStepProps {
   email: string;
+  isLoading?: boolean;
   onNext: (data: { email: string }) => void;
 }
 
 export interface CodeVerificationStepProps {
   email: string;
+  sentAt: number;
+  isLoading?: boolean;
+  isResending?: boolean;
+  isError?: boolean;
   onNext: (data: { code: string }) => void;
   onResend: () => void;
 }
 
 export interface PasswordResetStepProps {
+  isLoading?: boolean;
   onComplete: (data: { password: string }) => void;
 }

--- a/src/types/passwordReset/funnel.type.ts
+++ b/src/types/passwordReset/funnel.type.ts
@@ -32,7 +32,7 @@ export interface CodeVerificationStepProps {
   isResending?: boolean;
   isError?: boolean;
   onNext: (data: { code: string }) => void;
-  onResend: () => void;
+  onResend: () => Promise<void>;
 }
 
 export interface PasswordResetStepProps {


### PR DESCRIPTION
## 💡 PR 타입

- [x] 기능 추가
- [ ] 버그 수정
- [ ] 코드 개선
- [ ] 문서 수정
- [ ] 기타

## 📝 PR 내용

- 기존 비밀번호 재설정 Funnel 구조에 API를 연동했습니다.
  - 이메일 입력 단계에서 비밀번호 재설정 인증 메일 요청 API를 연결했습니다.
  - 인증 메일 요청 성공 시 코드 인증 페이지로 라우팅하도록 구현했습니다.
  - 코드 인증 API를 연동하고, 인증 실패 시 에러 메시지가 표시되도록 처리했습니다.
  - 코드 인증 성공 시 비밀번호 재설정 페이지로 이동하도록 연결했습니다.
  - 비밀번호 재설정 PUT API를 연동하고, 완료 시 로그인 페이지로 이동하도록 구현했습니다.
  
## 🔍 관련 이슈

- closes #63 

## 📸 작업 화면
<img width="362" height="168" alt="스크린샷 2026-03-14 오후 11 08 49" src="https://github.com/user-attachments/assets/8502ea31-1251-4c58-9d11-5e841b7f1b01" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 비밀번호 재설정 플로우 추가: 이메일로 인증 코드 발송, 코드 검증, 비밀번호 변경 단계를 포함한 완전한 흐름 제공
  * 재전송 및 진행 상태(로딩) 표시로 사용성 개선

* **다국어 지원**
  * 한국어 및 영어에 "유효하지 않은 인증 코드" 오류 메시지 추가

* **버그 수정 / 안정성**
  * 코드 검증 및 재전송 과정의 오류 표시 및 버튼 비활성화 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->